### PR TITLE
added link to nvim-commaround

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,7 @@ Treesitter is a new system coming in Neovim 0.5 that incrementally parses your c
 - [b3nj5m1n/kommentary](https://github.com/b3nj5m1n/kommentary) - Commenting plugin written in lua.
 - [glepnir/prodoc.nvim](https://github.com/glepnir/prodoc.nvim) - comment and
   support generate annotation
+- [gennaro-tedesco/nvim-commaround](https://github.com/gennaro-tedesco/nvim-commaround) - Fast and light commenting plugin written in Lua.
 
 ### Collaborative Editing
 


### PR DESCRIPTION
Hi all,

I would like to submit for review a link to a plugin of mine: `nvim-commaround`. It is a lightweight plugin that toggles comments for visual blocks based on the buffer filetype.

I have added the link in the corresponding section, as I thought it can be a nice addition to the lot. 