### PR TITLE
added link to nvim-peekup

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,10 @@ Neovim supports a wide variety of UI's.
 - [norcalli/snippets.nvim](https://github.com/norcalli/snippets.nvim)
 - [hrsh7th/vim-vsnip](https://github.com/hrsh7th/vim-vsnip) - Snippet plugin for vim/nvim that supports LSP/VSCode's snippet format.
 
+### Registers
+
+- [gennaro-tedesco/nvim-peekup](https://github.com/gennaro-tedesco/nvim-peekup) - Dynamically interact with vim registers
+
 ### Fuzzy Finder
 
 - [nvim-telescope/telescope.nvim](https://github.com/nvim-telescope/telescope.nvim) - `telescope.nvim` is a highly extendable fuzzy finder over lists. Built on the latest awesome features from `neovim` core. Telescope is centered around modularity, allowing for easy customization.


### PR DESCRIPTION
I would like to bring to your attention a plugin I wrote that allows to dynamically interact with vim registers: `nvim-peekup`. The content of vim registers is presented in a floating window and the user may select the one they need to yank and paste, receiving visual confirmation of their choice.