### PR TITLE
Add sniprun to the list

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,6 +242,10 @@ Treesitter is a new system coming in Neovim 0.5 that incrementally parses your c
 
 - [tjdevries/train.nvim](https://github.com/tjdevries/train.nvim) - Train yourself with vim motions and make your own train tracks :)
 
+### Code Runner
+
+- [michaelb/sniprun](https://github.com/michaelb/sniprun) - Run parts of code of any language directly from Neovim.
+
 ### GitHub
 
 - [pwntester/octo.nvim](https://github.com/pwntester/octo.nvim) - Plugin to work with GitHub issues and PRs from Neovim. Just edit the issue description


### PR DESCRIPTION
While the awesomeness is subject to bias, it is definitively a Neovim exclusive, and the technology (RPC + Lua + Rust) makes it somehow interesting.
Also, I noticed it actually superseed some of the plugins in the list ( namely [bfredl/nvim-luadev](https://github.com/bfredl/nvim-luadev) )

I don't feel extremely proud of needing a new category just for myself, but it doesn't really fit into any existing one (the lack of solutions was actually what led me to develop it)