### PR TITLE
Add nvenv and neva

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,6 +307,9 @@ Treesitter is a new system coming in Neovim 0.5 that incrementally parses your c
 
 ## Others
 
+### Version Managers
+- [NTBBloodbath/nvenv](https://github.com/NTBBloodbath/nvenv) - A lightweight and blazing fast Neovim version manager.
+
 [Vimawesome](https://vimawesome.com/) showcases various plugins for vim and has a [neovim tag](https://vimawesome.com/?q=tag:neovim) for other plugins targeting neovim.
 
 ### Vim Plugins

--- a/README.md
+++ b/README.md
@@ -309,6 +309,7 @@ Treesitter is a new system coming in Neovim 0.5 that incrementally parses your c
 
 ### Version Managers
 - [NTBBloodbath/nvenv](https://github.com/NTBBloodbath/nvenv) - A lightweight and blazing fast Neovim version manager.
+- [shohi/neva](https://github.com/shohi/neva) - A Neovim version manager written in Lua
 
 [Vimawesome](https://vimawesome.com/) showcases various plugins for vim and has a [neovim tag](https://vimawesome.com/?q=tag:neovim) for other plugins targeting neovim.
 


### PR DESCRIPTION
I made a small version manager for Neovim. You will also find [neva], which performs the same function and is written in Lua.

I didn't know where to put it, so I created a subcategory in `Others`. If it is deemed necessary to change it to another location, put it in a comment :)

They're both very fast and lightweight, however there are some differences that I have listed below.

Advantages of using nvenv over neva:
- nvenv is an executable, so you don't need to install a language to run it (Lua needs to have it installed to run neva)
- use dependencies that you can easily install with any package manager like jq (instead of gojq)
- being an executable, it runs natively (obviously)

Edit: I've also added neva to the `Version Managers` list

[neva]: https://github.com/shohi/neva