### PR TITLE
Removed duplicate

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,6 @@ Treesitter is a new system coming in Neovim 0.5 that incrementally parses your c
 - [RRethy/nvim-base16](https://github.com/RRethy/nvim-base16) - Neovim plugin for building base16 colorschemes. Includes support for Treesitter and LSP highlight groups.
 - [fenetikm/falcon](https://github.com/fenetikm/falcon) - A colour scheme for terminals, Vim and friends.
 - [maaslalani/nordbuddy](https://github.com/maaslalani/nordbuddy) - A nord-esque colorscheme using colorbuddy.nvim
-- [marko-cerovac/material.nvim](https://github.com/marko-cerovac/material.nvim) - Material colorscheme for NeoVim written in lua
 - [MordechaiHadad/nvim-papadark](https://github.com/MordechaiHadad/nvim-papadark) - My own neovim colorscheme
 - [ishan9299/nvim-solarized-lua](https://github.com/ishan9299/nvim-solarized-lua) - solarized colorscheme in lua for nvim 0.5
 


### PR DESCRIPTION
There were two marko-cerovac/material.nvim entries in the Treesitter Supported Colorschemes section, so I removed the last one