### PR TITLE
fix: logo url

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Collections of awesome [Neovim](https://neovim.io/) plugins. Mostly targeting Neovim specific features.
 
-![Neovim Logo](https://neovim.io/images/logo@2x.png)
+![Neovim Logo](https://raw.githubusercontent.com/neovim/neovim.github.io/master/logos/neovim-logo-300x87.png)
 
 ## Submissions
 


### PR DESCRIPTION
In my environment, the logo was not displayed correctly.
Therefore, the URL has been corrected.

Before:

![image](https://user-images.githubusercontent.com/16581287/115182033-2c533300-a114-11eb-9987-fa66838be5da.png)


After:

![image](https://user-images.githubusercontent.com/16581287/115182011-22c9cb00-a114-11eb-808b-39de6f2efac1.png)
