### PR TITLE
Add vim-code-dark with new treesitter support

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ Neovim supports a wide variety of UI's.
 
 Treesitter is a new system coming in Neovim 0.5 that incrementally parses your code into a tree that works, even with errors in your syntax. These colorschemes have specifically set colors for treesitter highlight groups. Vim colorschemes will work with the new groups out of the box.
 
+- [tomasiser/vim-code-dark] (https://github.com/tomasiser/vim-code-dark) - A dark color scheme heavily inspired by the look of the Dark+ scheme of Visual Studio Code
 - [marko-cerovac/material.nvim](https://github.com/marko-cerovac/material.nvim) - material.nvim is a highly configurable colorscheme written in lua and based on the material palette
 - [bluz71/vim-nightfly-guicolors](https://github.com/bluz71/vim-nightfly-guicolors) - nightfly is a dark GUI color scheme heavily inspired by Sarah Drasner's Night Owl theme.
 - [bluz71/vim-moonfly-colors](https://github.com/bluz71/vim-moonfly-colors) - moonfly is a dark color scheme with Treesitter support


### PR DESCRIPTION
The theme now has treesitter support since https://github.com/tomasiser/vim-code-dark/commit/2c11cee108fd2cdcdb0e1d814880494774c3c8ec