### PR TITLE
Add bufdelete.nvim

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,6 +241,7 @@ Treesitter is a new system coming in Neovim 0.5 that incrementally parses your c
 ### Utility
 
 - [famiu/nvim-reload](https://github.com/famiu/nvim-reload) - Easily reload your Neovim config.
+- [famiu/bufdelete.nvim](https://github.com/famiu/bufdelete.nvim) - Delete Neovim buffers without losing your window layout.
 
 ### Icons
 


### PR DESCRIPTION
[bufdelete.nvim](https://github.com/famiu/bufdelete.nvim) is a Neovim plugin that allows you to delete Neovim buffers without using your window layout by providing some commands that you can use instead of Neovim's built-in commands. It would be nice if this plugin was added to the list.