### PR TITLE
Adding nvim-dap-ui

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ Neovim supports a wide variety of UI's.
 - [nanotee/sqls.nvim](https://github.com/nanotee/sqls.nvim) - sqls (sql database connection plugin + LSP client) plugin for nvim
 - [jubnzv/virtual-types.nvim](https://github.com/jubnzv/virtual-types.nvim) - Neovim plugin that shows type annotations as virtual text
 - [jose-elias-alvarez/nvim-lsp-ts-utils](https://github.com/jose-elias-alvarez/nvim-lsp-ts-utils) - Utilities to improve the TypeScript development experience for Neovim's built-in LSP client.
+- [liuchengxu/vista.vim](https://github.com/liuchengxu/vista.vim) - List all functions and variables in a window of your current file.
 
 ##### LSP Installers
 


### PR DESCRIPTION
Adding the [nvim-dap-ui](https://github.com/rcarriga/nvim-dap-ui) extension for nvim-dap.