### PR TITLE
Add nvim-treesitter-textsubjects

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,7 @@ Neovim supports a wide variety of UI's.
 
 - [nvim-treesitter/nvim-treesitter](https://github.com/nvim-treesitter/nvim-treesitter) - Nvim Treesitter configurations and abstraction layer.
 - [nvim-treesitter/nvim-treesitter-textobject](https://github.com/nvim-treesitter/nvim-treesitter-textobjects) - Create your own textobjects using tree-sitter queries.
+- [RRethy/nvim-treesitter-textsubjects](https://github.com/RRethy/nvim-treesitter-textsubjects) - Location and syntax aware text objects which *do what you mean*.
 
 ### Terminal integration
 


### PR DESCRIPTION
I've added to the syntax category to the other nvim-treesitter plugins as I think they fit. Alternatively, it could be put under "Editing-Support".