### PR TITLE
Add `nvim-cartographer` to Keybindings section

### DIFF
--- a/README.md
+++ b/README.md
@@ -503,7 +503,7 @@ Treesitter is a new system coming in Neovim 0.5 that incrementally parses your c
 
 - [AckslD/nvim-whichkey-setup.lua](https://github.com/AckslD/nvim-whichkey-setup.lua) - Nvim-plugin what wraps vim-which-key to simplify setup in lua.
 - [folke/which-key.nvim](https://github.com/folke/which-key.nvim) - Neovim plugin that shows a popup with possible keybindings of the command you started typing.
-- [Iron-E/nvim-cartographer](https://github.com/Iron-E/nvim-cartographer) - a more convenient `:map`ping syntax for Lua environments
+- [Iron-E/nvim-cartographer](https://github.com/Iron-E/nvim-cartographer) - a more convenient `:map`ping syntax for Lua environments.
 
 ### Tmux
 

--- a/README.md
+++ b/README.md
@@ -503,6 +503,7 @@ Treesitter is a new system coming in Neovim 0.5 that incrementally parses your c
 
 - [AckslD/nvim-whichkey-setup.lua](https://github.com/AckslD/nvim-whichkey-setup.lua) - Nvim-plugin what wraps vim-which-key to simplify setup in lua.
 - [folke/which-key.nvim](https://github.com/folke/which-key.nvim) - Neovim plugin that shows a popup with possible keybindings of the command you started typing.
+- [Iron-E/nvim-cartographer](https://github.com/Iron-E/nvim-cartographer) - a more convenient `:map`ping syntax for Lua environments
 
 ### Tmux
 


### PR DESCRIPTION
I created this plugin to help users create keymaps more easily in Lua, as the `vim.api.nvim_set_keymap` is a tad verbose compared to the nice `:map` syntax we had in VimL. 

You can see it in action [here](https://gitlab.com/Iron_E/dotfiles/-/blob/master/.config/nvim/lua/init/mappings.lua).