### PR TITLE
Remove nvim-compe as it was deprecated

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,6 @@ Neovim supports a wide variety of UI's.
 ### Completion
 
 - [nvim-lua/completion-nvim](https://github.com/nvim-lua/completion-nvim) - An async completion framework aims to provide completion to neovim's built in LSP written in Lua.
-- [hrsh7th/nvim-compe](https://github.com/hrsh7th/nvim-compe) - Auto completion plugin for nvim written in Lua.
 - [hrsh7th/nvim-cmp](https://github.com/hrsh7th/nvim-cmp) - A completion plugin for neovim written in Lua. New version of nvim-compe.
 - [ms-jpq/coq_nvim](https://github.com/ms-jpq/coq_nvim) - Fast as FUCK nvim completion. SQLite, concurrent scheduler, hundreds of hours of optimization.
 


### PR DESCRIPTION
[nvim-compe](https://github.com/hrsh7th/nvim-compe) is now deprecated in favor of [nvim-cmp](https://github.com/hrsh7th/nvim-cmp) (see: https://github.com/hrsh7th/nvim-compe/commit/203bb64f97093bf037bcde8f5633891c996580b1). New features and bugfixes will be stopped so I think we should remove this from this list.

Thx !