### PR TITLE
Add nest.nvim to keybinding section

### DIFF
--- a/README.md
+++ b/README.md
@@ -563,6 +563,7 @@ These colorschemes may not specialize in Tree-sitter directly but are written in
 - [folke/which-key.nvim](https://github.com/folke/which-key.nvim) - Neovim plugin that shows a popup with possible keybindings of the command you started typing.
 - [Iron-E/nvim-cartographer](https://github.com/Iron-E/nvim-cartographer) - a more convenient `:map`ping syntax for Lua environments.
 - [b0o/mapx.lua](https://github.com/b0o/mapx.lua) - A small lua library providing a simpler key mapping API that mimics vim's builtin `:map`-family of commands. Integrates with which-key.nvim.
+- [LionC/nest.nvim](https://github.com/LionC/nest.nvim) - Lua utility to map keys concisely using cascading trees. Also allows binding Lua functions to keys.
 
 ### Tmux
 


### PR DESCRIPTION
Checklist:
- [x] The plugin is specifically build for Neovim.
- [x] The lines end with a `.`. This is to conform to `awesome-list` linting and requirements.
- [x] It's not already on the list. 
- [x] It supports treesitter syntax if it's a colorscheme.

This adds [nest.nvim](https://github.com/LionC/nest.nvim), which I published about a month ago. It is a small lua utility that allows to bind keys in a concise cascading tree syntax with some QOL features.