### PR TITLE
Update Mapx title/description

### DIFF
--- a/README.md
+++ b/README.md
@@ -562,7 +562,7 @@ These colorschemes may not specialize in Tree-sitter directly but are written in
 - [AckslD/nvim-whichkey-setup.lua](https://github.com/AckslD/nvim-whichkey-setup.lua) - Nvim-plugin what wraps vim-which-key to simplify setup in lua.
 - [folke/which-key.nvim](https://github.com/folke/which-key.nvim) - Neovim plugin that shows a popup with possible keybindings of the command you started typing.
 - [Iron-E/nvim-cartographer](https://github.com/Iron-E/nvim-cartographer) - a more convenient `:map`ping syntax for Lua environments.
-- [b0o/mapx.lua](https://github.com/b0o/mapx.lua) - A small lua library providing a simpler key mapping API that mimics vim's builtin `:map`-family of commands. Integrates with which-key.nvim.
+- [b0o/mapx.nvim](https://github.com/b0o/mapx.nvim) - A simpler key mapping API that mimics Nvim's `:map`-family of commands. Integrates with which-key.nvim.
 
 ### Tmux
 


### PR DESCRIPTION
I recently renamed the Mapx repository from mapx.lua to mapx.nvim.