### PR TITLE
Add Substrata color scheme

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,6 +289,7 @@ Tree-sitter is a new system coming in Neovim 0.5 that incrementally parses your 
 - [Pocco81/Catppuccino.nvim](https://github.com/Pocco81/Catppuccino.nvim) - An eye-candy and full-featured Neovim theme with support for native LSP, Tree-sitter, and more 🍨!
 - [FrenzyExists/aquarium-vim](https://github.com/FrenzyExists/aquarium-vim) - A dark, yet vibrant colorscheme for neovim.
 - [EdenEast/nightfox.nvim](https://github.com/EdenEast/nightfox.nvim) - A soft dark, fully customizable Neovim theme, with support for lsp, treesitter and a variety of plugins.
+- [kvrohit/substrata.nvim](https://github.com/kvrohit/substrata.nvim) - A cold, dark color scheme for Neovim written in Lua ported from [arzg/vim-substrata](https://github.com/arzg/vim-substrata) theme.
 
 #### Lua Colorscheme
 


### PR DESCRIPTION
Checklist:
- [x] The plugin is specifically build for Neovim.
- [x] The lines end with a `.`. This is to conform to `awesome-list` linting and requirements.
- [x] It's not already on the list. 
- [x] It supports treesitter syntax if it's a colorscheme.
