### PR TITLE
add apprentice.nvim color scheme

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,6 +290,7 @@ Tree-sitter is a new system coming in Neovim 0.5 that incrementally parses your 
 - [FrenzyExists/aquarium-vim](https://github.com/FrenzyExists/aquarium-vim) - A dark, yet vibrant colorscheme for neovim.
 - [EdenEast/nightfox.nvim](https://github.com/EdenEast/nightfox.nvim) - A soft dark, fully customizable Neovim theme, with support for lsp, treesitter and a variety of plugins.
 - [kvrohit/substrata.nvim](https://github.com/kvrohit/substrata.nvim) - A cold, dark color scheme for Neovim written in Lua ported from [arzg/vim-substrata](https://github.com/arzg/vim-substrata) theme.
+- [adisen99/apprentice.nvim](https://github.com/adisen99/apprentice.nvim) - Colorscheme for neovim written in lua based on the [Apprentice](https://github.com/romainl/Apprentice) color pattete with Tree-sitter and built-in lsp support.
 
 #### Lua Colorscheme
 


### PR DESCRIPTION
Checklist:
- [x] The plugin is specifically build for Neovim.
- [x] The lines end with a `.`. This is to conform to `awesome-list` linting and requirements.
- [x] It's not already on the list. 
- [x] It supports treesitter syntax if it's a colorscheme.
