### PR TITLE
add link for sbdchd/neoformat

### DIFF
--- a/README.md
+++ b/README.md
@@ -519,6 +519,7 @@ These colorschemes may not specialize in Tree-sitter directly but are written in
 
 - [mhartington/formatter.nvim](https://github.com/mhartington/formatter.nvim) - A format runner for Neovim written in Lua.
 - [lukas-reineke/format.nvim](https://github.com/lukas-reineke/format.nvim) - Fast asynchronous formatting for Neovim. Supports formatting embedded code blocks.
+- [sbdchd/neoformat](https://github.com/sbdchd/neoformat) - A (Neo)vim plugin for formatting code.
 
 ### Web development
 


### PR DESCRIPTION
Checklist:
- [x] The plugin is specifically build for Neovim.
- [x] The lines end with a `.`. This is to conform to `awesome-list` linting and requirements.
- [x] It's not already on the list. 
- [x] It supports treesitter syntax if it's a colorscheme.

add link: [sbdchd/neoformat](https://github.com/sbdchd/neoformat)