### PR TITLE
docs: add weilbith/nvim-code-action-menu.

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ Neovim supports a wide variety of UI's.
 - [jose-elias-alvarez/null-ls](https://github.com/jose-elias-alvarez/null-ls.nvim) - Use Neovim as a language server to inject LSP diagnostics, code actions, and more via Lua.
 - [jakewvincent/texmagic.nvim](https://github.com/jakewvincent/texmagic.nvim) - Enhance the lspconfig settings for Texlab by defining any number of custom LaTeX build engines and selecting them with magic comments.
 - [nanotee/nvim-lsp-basics](https://github.com/nanotee/nvim-lsp-basics) - Basic wrappers for LSP features.
-- [weilbith/nvim-code-action-menu](https://github.com/nanotee/nvim-lsp-basics) - A floating pop-up menu for code actions to show code action information and a diff preview.
+- [weilbith/nvim-code-action-menu](https://github.com/weilbith/nvim-code-action-menu - A floating pop-up menu for code actions to show code action information and a diff preview.
 
 ##### LSP Installer
 

--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ Neovim supports a wide variety of UI's.
 - [jose-elias-alvarez/null-ls](https://github.com/jose-elias-alvarez/null-ls.nvim) - Use Neovim as a language server to inject LSP diagnostics, code actions, and more via Lua.
 - [jakewvincent/texmagic.nvim](https://github.com/jakewvincent/texmagic.nvim) - Enhance the lspconfig settings for Texlab by defining any number of custom LaTeX build engines and selecting them with magic comments.
 - [nanotee/nvim-lsp-basics](https://github.com/nanotee/nvim-lsp-basics) - Basic wrappers for LSP features.
-- [weilbith/nvim-code-action-menu](https://github.com/weilbith/nvim-code-action-menu - A floating pop-up menu for code actions to show code action information and a diff preview.
+- [weilbith/nvim-code-action-menu](https://github.com/weilbith/nvim-code-action-menu) - A floating pop-up menu for code actions to show code action information and a diff preview.
 
 ##### LSP Installer
 

--- a/README.md
+++ b/README.md
@@ -141,6 +141,7 @@ Neovim supports a wide variety of UI's.
 - [jose-elias-alvarez/null-ls](https://github.com/jose-elias-alvarez/null-ls.nvim) - Use Neovim as a language server to inject LSP diagnostics, code actions, and more via Lua.
 - [jakewvincent/texmagic.nvim](https://github.com/jakewvincent/texmagic.nvim) - Enhance the lspconfig settings for Texlab by defining any number of custom LaTeX build engines and selecting them with magic comments.
 - [nanotee/nvim-lsp-basics](https://github.com/nanotee/nvim-lsp-basics) - Basic wrappers for LSP features.
+- [weilbith/nvim-code-action-menu](https://github.com/nanotee/nvim-lsp-basics) - A floating pop-up menu for code actions to show code action information and a diff preview.
 
 ##### LSP Installer
 


### PR DESCRIPTION
A plugin that adds A floating pop-up menu for code actions to show code action information and a diff preview.

Checklist:
- [x] The plugin is specifically build for Neovim.
- [x] The lines end with a `.`. This is to conform to `awesome-list` linting and requirements.
- [x] It's not already on the list. 
