### PR TITLE
Add gkeep.nvim

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,6 +216,7 @@ Neovim supports a wide variety of UI's.
 - [kristijanhusak/orgmode.nvim](https://github.com/kristijanhusak/orgmode.nvim) - Orgmode clone written in Lua for Neovim 0.5+.
 - [NFrid/due.nvim](https://github.com/NFrid/due.nvim) - Displays due for a date string as a virtual text.
 - [jbyuki/venn.nvim](https://github.com/jbyuki/venn.nvim) - Draw ASCII diagrams in Neovim.
+- [stevearc/gkeep.nvim](https://github.com/stevearc/gkeep.nvim) - Google Keep integration for Neovim.
 
 ### Color
 


### PR DESCRIPTION
Checklist:
- [x] The plugin is specifically build for Neovim.
- [x] The lines end with a `.`. This is to conform to `awesome-list` linting and requirements.
- [x] It's not already on the list. 
- [x] It supports treesitter syntax if it's a colorscheme.
