### PR TITLE
add numToStr/Comment.nvim

### DIFF
--- a/README.md
+++ b/README.md
@@ -441,6 +441,7 @@ These colorschemes may not specialize in Tree-sitter directly but are written in
 
 ### Comment
 
+- [numToStr/Comment.nvim](https://github.com/numToStr/Comment.nvim) - Smart and Powerful comment plugin for neovim. Supports commentstring, motions, dot-repeat and more.
 - [b3nj5m1n/kommentary](https://github.com/b3nj5m1n/kommentary) - Commenting plugin written in lua.
 - [glepnir/prodoc.nvim](https://github.com/glepnir/prodoc.nvim) - Comment and support generate annotation.
 - [gennaro-tedesco/nvim-commaround](https://github.com/gennaro-tedesco/nvim-commaround) - Fast and light commenting plugin written in Lua.


### PR DESCRIPTION
Checklist:
- [x] The plugin is specifically build for Neovim.
- [x] The lines end with a `.`. This is to conform to `awesome-list` linting and requirements.
- [x] It's not already on the list.

Added [numToStr/Comment.nvim](https://github.com/numToStr/Comment.nvim). A new kid in the commenting town :)