### PR TITLE
Add two new plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -553,6 +553,7 @@ These colorschemes may not specialize in Tree-sitter directly but are written in
 ### Command Line
 
 - [notomo/cmdbuf.nvim](https://github.com/notomo/cmdbuf.nvim) - Alternative command-line-window plugin.
+- [gelguy/wilder.nvim](https://github.com/gelguy/wilder.nvim) - A plugin for fuzzy command line autocompletion.
 
 ### Session
 


### PR DESCRIPTION
Nvim-notify can show notifications on floating windows, which is a very cool feature.

Wilder.nvim provides fuzzy autocompletion for the command line.

Checklist:
- [x] The plugin is specifically build for Neovim.
- [x] The lines end with a `.`. This is to conform to `awesome-list` linting and requirements.
- [x] It's not already on the list. 