### PR TITLE
Add marks.nvim

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Collections of awesome [Neovim](https://neovim.io/) plugins. Mostly targeting Ne
   - [Terminal integration](#terminal-integration)
   - [Snippet](#snippet)
   - [Register](#register)
+  - [Marks](#marks)
   - [Fuzzy Finder](#fuzzy-finder)
   - [Note Taking](#note-taking)
   - [Color](#color)
@@ -199,6 +200,10 @@ Neovim supports a wide variety of UI's.
 - [gennaro-tedesco/nvim-peekup](https://github.com/gennaro-tedesco/nvim-peekup) - Dynamically interact with vim registers.
 - [tversteeg/registers.nvim](https://github.com/tversteeg/registers.nvim) - Non-obtrusive minimal preview of vim registers.
 - [acksld/nvim-neoclip.lua](https://github.com/AckslD/nvim-neoclip.lua) - Clipboard manager neovim plugin with telescope integration.
+
+### Marks
+
+- [chentau/marks.nvim](https://github.com/chentau/marks.nvim) - A better user experience for viewing and interacting with vim marks.
 
 ### Fuzzy Finder
 


### PR DESCRIPTION
marks.nvim lets users view marks in the sign column, move between marks, and quickly toggle marks on and off. It also implements bookmarks, which allow for quick movement across multiple files.

If it's alright with you, I made a new category, since I wan't quite sure where the plugin would fit in with the existing headers.

Checklist:
- [x] The plugin is specifically build for Neovim.
- [x] The lines end with a `.`. This is to conform to `awesome-list` linting and requirements.
- [x] It's not already on the list.
