### PR TITLE
update lualines location

### DIFF
--- a/README.md
+++ b/README.md
@@ -374,7 +374,7 @@ These colorschemes may not specialize in Tree-sitter directly but are written in
 
 - [NTBBloodbath/galaxyline.nvim](https://github.com/NTBBloodbath/galaxyline.nvim) - Galaxyline componentizes Vim's statusline by having a provider for each text area. This means you can use the api provided by galaxyline to create the statusline that you want, easily.
 - [tjdevries/express_line.nvim](https://github.com/tjdevries/express_line.nvim) - Supports co-routines, functions and jobs.
-- [hoob3rt/lualine.nvim](https://github.com/hoob3rt/lualine.nvim) - A blazing fast and easy to configure neovim statusline.
+- [nvim-lualine/lualine.nvim](https://github.com/nvim-lualine/lualine.nvim) - A blazing fast and easy to configure neovim statusline.
 - [adelarsq/neoline.vim](https://github.com/adelarsq/neoline.vim) - A light statusline/tabline plugin for Neovim using Lua.
 - [ojroques/nvim-hardline](https://github.com/ojroques/nvim-hardline) - A statusline / bufferline. It is inspired by [vim-airline](https://github.com/vim-airline/vim-airline) but aims to be as light and simple as possible.
 - [datwaft/bubbly.nvim](https://github.com/datwaft/bubbly.nvim) - Bubbly status line for neovim.


### PR DESCRIPTION
Checklist:
- [x] The plugin is specifically build for Neovim.
- [x] The lines end with a `.`. This is to conform to `awesome-list` linting and requirements.
- [ ] ~It's not already on the list.~ 
- [ ] ~It supports treesitter syntax if it's a colorscheme.~

[hoobrt/lualine](https://github.com/hoob3rt/lualine.nvim) has been unmaintained for quite a while. I've been maintaining a fork of [lualine](https://github.com/nvim-lualine/lualine.nvim). And @hoob3rt hasn't responded in this time . You can check out [this pr](https://github.com/hoob3rt/lualine.nvim/pull/311) .

@rockerBOO can I change the link to lualine to it's fork ?
