### PR TITLE
Replace deprecated lsp-rooter.nvim

### DIFF
--- a/README.md
+++ b/README.md
@@ -507,7 +507,7 @@ These colorschemes may not specialize in Tree-sitter directly but are written in
 
 - [windwp/nvim-projectconfig](https://github.com/windwp/nvim-projectconfig) - Load neovim config depend on project directory.
 - [windwp/nvim-spectre](https://github.com/windwp/nvim-spectre) - Search and replace panel for neovim.
-- [ahmedkhalf/lsp-rooter.nvim](https://github.com/ahmedkhalf/lsp-rooter.nvim) - Automatically change the current working directory to the project's working directory using the native LSP.
+- [ahmedkhalf/project.nvim](https://github.com/ahmedkhalf/project.nvim) - An all in one neovim plugin that provides superior project management.
 
 ### Browser integration
 


### PR DESCRIPTION
Lsp-rooter.nvim was deprecated a while ago and the focus was shifted towards project.nvim.

Checklist:
- [x] The plugin is specifically build for Neovim.
- [x] The lines end with a `.`. This is to conform to `awesome-list` linting and requirements.
- [x] It's not already on the list. 
- [ ] It supports treesitter syntax if it's a colorscheme.
