### PR TITLE
added b0o/SchemaStore.nvim

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,7 @@ Neovim supports a wide variety of UI's.
 - [nanotee/nvim-lsp-basics](https://github.com/nanotee/nvim-lsp-basics) - Basic wrappers for LSP features.
 - [weilbith/nvim-code-action-menu](https://github.com/weilbith/nvim-code-action-menu) - A floating pop-up menu for code actions to show code action information and a diff preview.
 - [mfussenegger/nvim-lint](https://github.com/mfussenegger/nvim-lint) - An asynchronous linter plugin for Neovim (>= 0.5) complementary to the built-in Language Server Protocol support.
+- [b0o/SchemaStore.nvim](https://github.com/b0o/SchemaStore.nvim) - A Neovim Lua plugin providing access to the [SchemaStore](https://github.com/SchemaStore/schemastore) catalog.
 
 ##### LSP Installer
 


### PR DESCRIPTION
Checklist:
- [x] The plugin is specifically build for Neovim.
- [x] The lines end with a `.`. This is to conform to `awesome-list` linting and requirements.
- [x] It's not already on the list. 
- [x] It supports treesitter syntax if it's a colorscheme.

This is a plugin that adds schemas from the [SchemaStore](https://github.com/SchemaStore/schemastore) for the [vscode-json-languageserver](https://github.com/vscode-langservers/vscode-json-languageserver) when using [nvim-lspconfig](https://github.com/neovim/nvim-lspconfig).

I added it in the LSP category and I'll notify the maintainer after creating this PR.