### PR TITLE
Adding rafaelsq/nvim-goc.lua

### DIFF
--- a/README.md
+++ b/README.md
@@ -462,6 +462,7 @@ These colorschemes may not specialize in Tree-sitter directly but are written in
 - [gennaro-tedesco/nvim-jqx](https://github.com/gennaro-tedesco/nvim-jqx) - Interactive interface for json files.
 - [edolphin-ydf/goimpl.nvim](https://github.com/edolphin-ydf/goimpl.nvim) - Generate interface stubs for a type.
 - [lean.nvim](https://github.com/Julian/lean.nvim) - Neovim support for the [Lean Theorem Prover](https://leanprover.github.io/).
+- [rafaelsq/nvim-goc.lua](https://github.com/rafaelsq/nvim-goc.lua) - Highlight your buffer with Golang Code Coverage.
 
 ### Comment
 


### PR DESCRIPTION
Checklist:

- [x] The plugin is specifically built for Neovim.
- [x] The lines end with a `.`. This is to conform to `awesome-list` linting and requirements.
- [x] It's not already on the list.
- [x] It supports treesitter syntax if it's a colorscheme.
