### PR TITLE
Add neoivim-gtk to the list of UI options

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ Neovim supports a wide variety of UI's.
 - [vv-vim/vv](https://github.com/vv-vim/vv) - Neovim client for macOS. A pure, fast, minimalistic Vim experience with good macOS integration. Optimized for speed and nice font rendering.
 - [jebberjeb/javafx-neovimpane](https://github.com/jebberjeb/javafx-neovimpane) - A JavaFX text pane, backed by Neovim, created with Clojure.
 - [rohit-px2/nvui](https://github.com/rohit-px2/nvui) - A modern frontend for Neovim.
+- [Lyude/neovim-gtk](https://github.com/Lyude/neovim-gtk) - A GTK3+ client written in Rust, ressembling a lot the original vim-gtk3 with ligatures support.
 
 ## Plugin
 


### PR DESCRIPTION
Fix https://github.com/rockerBOO/awesome-neovim/issues/249

Checklist:

- [x] The plugin is specifically built for Neovim.
- [x] The lines end with a `.`. This is to conform to `awesome-list` linting and requirements.
- [x] It's not already on the list.
- [x] It supports treesitter syntax if it's a colorscheme (not a colorscheme)
