### PR TITLE
Add `filipdutescu/renamer.nvim`

### DIFF
--- a/README.md
+++ b/README.md
@@ -585,6 +585,7 @@ These colorschemes may not specialize in Tree-sitter directly but are written in
 - [McAuleyPenney/tidy.nvim](https://github.com/McAuleyPenney/tidy.nvim) - Clear trailing whitespace and empty lines at end of file on every save.
 <!--lint ignore double-link-->
 - [mini.trailspace](https://github.com/echasnovski/mini.nvim#minitrailspace) - Module of [echasnovski/mini.nvim](https://github.com/echasnovski/mini.nvim) for automatic highlighting of trailing whitespace with functionality to remove it.
+- [filipdutescu/renamer.nvim](https://github.com/filipdutescu/renamer.nvim) - VS Code-like renaming UI for Neovim, writen in Lua.
 
 ### Formatting
 


### PR DESCRIPTION
Add a link to `filipdutescu/renamer.nvim` to the "Editing support" section.

Signed-off-by: Filip Dutescu <filip.dutescu@gmail.com>

Checklist:

- [x] The plugin is specifically built for Neovim.
- [x] The lines end with a `.`. This is to conform to `awesome-list` linting and requirements.
- [x] It's not already on the list.
- [ ] It supports treesitter syntax if it's a colorscheme.
