### PR TITLE
Add `klen/nvim-test`

### DIFF
--- a/README.md
+++ b/README.md
@@ -660,7 +660,7 @@ These colorschemes may not specialize in Tree-sitter directly but are written in
 
 - [rcarriga/vim-ultest](https://github.com/rcarriga/vim-ultest) - The ultimate testing plugin for NeoVim.
 - [David-Kunz/jester](https://github.com/David-Kunz/jester) - A Neovim plugin to easily run and debug Jest tests.
-- [klen/nvim-test](https://github.com/klen/nvim-test) - Test Runner for neovim
+- [klen/nvim-test](https://github.com/klen/nvim-test) - Test Runner for neovim.
 
 ### Competitive Programming
 

--- a/README.md
+++ b/README.md
@@ -660,6 +660,7 @@ These colorschemes may not specialize in Tree-sitter directly but are written in
 
 - [rcarriga/vim-ultest](https://github.com/rcarriga/vim-ultest) - The ultimate testing plugin for NeoVim.
 - [David-Kunz/jester](https://github.com/David-Kunz/jester) - A Neovim plugin to easily run and debug Jest tests.
+- [klen/nvim-test](https://github.com/klen/nvim-test) - Test Runner for neovim
 
 ### Competitive Programming
 

--- a/README.md
+++ b/README.md
@@ -661,7 +661,7 @@ These colorschemes may not specialize in Tree-sitter directly but are written in
 - [rcarriga/vim-ultest](https://github.com/rcarriga/vim-ultest) - The ultimate testing plugin for NeoVim.
 - [David-Kunz/jester](https://github.com/David-Kunz/jester) - A Neovim plugin to easily run and debug Jest tests.
 - [klen/nvim-test](https://github.com/klen/nvim-test) - A Neovim wrapper for running tests.
-- 
+
 ### Competitive Programming
 
 - [p00f/cphelper.nvim](https://github.com/p00f/cphelper.nvim) - Neovim helper for competitive programming written in Lua.

--- a/README.md
+++ b/README.md
@@ -660,8 +660,8 @@ These colorschemes may not specialize in Tree-sitter directly but are written in
 
 - [rcarriga/vim-ultest](https://github.com/rcarriga/vim-ultest) - The ultimate testing plugin for NeoVim.
 - [David-Kunz/jester](https://github.com/David-Kunz/jester) - A Neovim plugin to easily run and debug Jest tests.
-- [klen/nvim-test](https://github.com/klen/nvim-test) - Test Runner for neovim.
-
+- [klen/nvim-test](https://github.com/klen/nvim-test) - A Neovim wrapper for running tests.
+- 
 ### Competitive Programming
 
 - [p00f/cphelper.nvim](https://github.com/p00f/cphelper.nvim) - Neovim helper for competitive programming written in Lua.


### PR DESCRIPTION
Checklist:

- [x] The plugin is specifically built for Neovim.
- [x] The lines end with a `.`. This is to conform to `awesome-list` linting and requirements.
- [x] It's not already on the list.
- [ ] If it's a colorscheme, it supports treesitter syntax.

[nvim-test](https://github.com/klen/nvim-test)
