### PR TITLE
Add `cljoly/telescope-repo.nvim`

### DIFF
--- a/README.md
+++ b/README.md
@@ -597,6 +597,7 @@ These colorschemes may not specialize in Tree-sitter directly but are written in
 - [windwp/nvim-spectre](https://github.com/windwp/nvim-spectre) - Search and replace panel for Neovim.
 - [ahmedkhalf/project.nvim](https://github.com/ahmedkhalf/project.nvim) - An all in one Neovim plugin that provides superior project management.
 - [klen/nvim-config-local](https://github.com/klen/nvim-config-local) - Secure load local config files from working directories.
+- [cljoly/telescope-repo.nvim](https://cj.rs/telescope-repo-nvim/) - Telescope picker to jump to any repository (git or other) on the file system.
 
 ### Browser integration
 


### PR DESCRIPTION
Checklist:

- [X] The plugin is specifically built for Neovim.
- [X] The lines end with a `.`. This is to conform to `awesome-list` linting and requirements.
- [X] It's not already on the list.
- [X] If it's a colorscheme, it supports treesitter syntax.
- [X] The title of the pull request is ```Add `username/repo` ``` when adding a new plugin.

*Disclaimer*: I’m the author of that plugin, but it seems relatively popular and has been around for a while, so you might want to consider it for inclusion in that list.
