### PR TITLE
added file explorer plugin.

### DIFF
--- a/README.md
+++ b/README.md
@@ -502,6 +502,7 @@ These colorschemes may not specialize in Tree-sitter directly but are written in
 - [is0n/fm-nvim](https://github.com/is0n/fm-nvim) - Neovim plugin that lets you use your favorite terminal file managers (and fuzzy finders) from within Neovim.
 - [nvim-neo-tree/neo-tree.nvim](https://github.com/nvim-neo-tree/neo-tree.nvim) - Neo-tree is a Neovim plugin to browse the file system and other tree like structures in whatever style suits you, including sidebars, floating windows, netrw split style, or all of them at once.
 - [elihunter173/dirbuf.nvim](https://github.com/elihunter173/dirbuf.nvim) - A file manager for Neovim which lets you edit your filesystem like you edit text.
+- [ipod825/vim-netranger](https://github.com/ipod825/vim-netranger) - A ranger-like system/cloud storage explorer for Vim, bringing together the best of Vim, ranger, and rclone.
 
 ### Dependency management
 


### PR DESCRIPTION
vim-netranger plugin added to file explorer's list.

Checklist:

- [ ] The plugin is specifically built for Neovim.
- [ ] The lines end with a `.`. This is to conform to `awesome-list` linting and requirements.
- [ ] It's not already on the list.
- [ ] If it's a colorscheme, it supports treesitter syntax.
- [ ] The title of the pull request is ```Add `username/repo` ``` when adding a new plugin.
