### PR TITLE
Add `lervag/vimtex`

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,7 @@ Neovim supports a wide variety of UI's.
 - [kdheepak/panvimdoc](https://github.com/kdheepak/panvimdoc) - A pandoc to vimdoc GitHub action.
 - [frabjous/knap](https://github.com/frabjous/knap) - Plugin for creating automatic updating-as-you-type previews for markdown, LaTeX and other documents.
 - [jbyuki/carrot.nvim](https://github.com/jbyuki/carrot.nvim) - Markdown evaluator for Neovim Lua code blocks.
+- [lervag/vimtex](https://github.com/lervag/vimtex) - VimTeX: A modern Vim and neovim filetype plugin for LaTeX files.
 
 ### Syntax
 


### PR DESCRIPTION
Checklist:

- [x] The plugin is specifically built for Neovim.
- [x] The lines end with a `.`. This is to conform to `awesome-list` linting and requirements.
- [x] It's not already on the list.
- [x] If it's a colorscheme, it supports treesitter syntax.
- [x] The title of the pull request is ```Add `username/repo` ``` when adding a new plugin.

As far as I understood, my PR statement [`#381`](https://github.com/rockerBOO/awesome-neovim/pull/381) was wrong about `lervag/vimtex` not being a plugin specifically for Neovim. I told so just because it works on `vim` as well, but I've notice that there are other plugins in this list in the same situation.

I humbly ask to consider the insertion of this plugin to the list.