### PR TITLE
Remove `akinsho/dependency-assist.nvim`

### DIFF
--- a/README.md
+++ b/README.md
@@ -527,7 +527,6 @@ These colorschemes may not specialize in Tree-sitter directly but are written in
 
 ### Dependency management
 
-- [akinsho/dependency-assist.nvim](https://github.com/akinsho/dependency-assist.nvim) - Search for and add new dependencies (dart, for now but rust coming soon).
 - [vuki656/package-info.nvim](https://github.com/vuki656/package-info.nvim) - Display latest package version as virtual text in package.json.
 
 ### Git


### PR DESCRIPTION
This repository has been archived.

@akinsho can you verify that it's not intended for use anymore?
