### PR TITLE
Remove `tjdevries/gruvbuddy.nvim`

### DIFF
--- a/README.md
+++ b/README.md
@@ -365,7 +365,6 @@ Tree-sitter is a new system introduced in Neovim 0.5 that incrementally parses y
 
 These colorschemes may not specialize in Tree-sitter directly but are written in Lua.
 
-- [tjdevries/gruvbuddy.nvim](https://github.com/tjdevries/gruvbuddy.nvim) - Gruvbox colors.
 - [ellisonleao/gruvbox.nvim](https://github.com/ellisonleao/gruvbox.nvim) - Gruvbox community colorscheme Lua port.
 - [metalelf0/jellybeans-nvim](https://github.com/metalelf0/jellybeans-nvim) - A port of jellybeans colorscheme for Neovim.
 - [lalitmee/cobalt2.nvim](https://github.com/lalitmee/cobalt2.nvim) - A port of cobalt2 colorscheme for Neovim using colorbuddy.


### PR DESCRIPTION
This repo has not been updated since `2021-04-15 20:31:43 UTC`.
Can @tjdevries confirm whether this repo is still intended for use?