### PR TITLE
Remove `ThePrimeagen/vim-be-good`

### DIFF
--- a/README.md
+++ b/README.md
@@ -506,7 +506,6 @@ These colorschemes may not specialize in Tree-sitter directly but are written in
 
 ### Game
 
-- [ThePrimeagen/vim-be-good](https://github.com/ThePrimeagen/vim-be-good) - Vim-be-good is a Neovim plugin designed to make you better at Vim Movements.
 - [ThePrimeagen/vim-apm](https://github.com/ThePrimeagen/vim-apm) - Vim APM, Actions per minute, is the greatest plugin since vim-slicedbread.
 - [alec-gibson/nvim-tetris](https://github.com/alec-gibson/nvim-tetris) - Bringing emacs' greatest feature to Neovim - Tetris!.
 - [seandewar/nvimesweeper](https://github.com/seandewar/nvimesweeper) - Play Minesweeper in your favourite text editor.


### PR DESCRIPTION
This repo has not been updated since `2021-03-16 11:25:47 UTC`.
Can @ThePrimeagen confirm whether this repo is still intended for use?