### PR TITLE
Remove `glepnir/prodoc.nvim`

### DIFF
--- a/README.md
+++ b/README.md
@@ -556,7 +556,6 @@ These colorschemes may not specialize in Tree-sitter directly but are written in
 
 - [numToStr/Comment.nvim](https://github.com/numToStr/Comment.nvim) - Smart and Powerful comment plugin for Neovim. Supports commentstring, motions, dot-repeat and more.
 - [b3nj5m1n/kommentary](https://github.com/b3nj5m1n/kommentary) - Commenting plugin written in Lua.
-- [glepnir/prodoc.nvim](https://github.com/glepnir/prodoc.nvim) - Comment and support generate annotation.
 - [gennaro-tedesco/nvim-commaround](https://github.com/gennaro-tedesco/nvim-commaround) - Fast and light commenting plugin written in Lua.
 - [folke/todo-comments.nvim](https://github.com/folke/todo-comments.nvim) - Highlight, list and search todo comments in your projects.
 - [terrortylor/nvim-comment](https://github.com/terrortylor/nvim-comment) - Toggle comments in Neovim using the built-in commentstring option.


### PR DESCRIPTION
This repo has not been updated since `2021-01-23 07:02:26 UTC`.
Can @glepnir confirm whether this repo is still intended for use?