### PR TITLE
Remove `tjdevries/train.nvim`

### DIFF
--- a/README.md
+++ b/README.md
@@ -578,7 +578,6 @@ These colorschemes may not specialize in Tree-sitter directly but are written in
 
 ### Motion
 
-- [tjdevries/train.nvim](https://github.com/tjdevries/train.nvim) - Train yourself with vim motions and make your own train tracks.
 - [phaazon/hop.nvim](https://github.com/phaazon/hop.nvim) - Hop is an EasyMotion-like plugin allowing you to jump anywhere in a document with as few keystrokes as possible.
 - [ggandor/lightspeed.nvim](https://github.com/ggandor/lightspeed.nvim) - A Sneak-like plugin offering unparalleled navigation speed via ahead-of-time displayed labels, that eliminate the pause between entering the search pattern and selecting the target.
 - [ggandor/leap.nvim](https://github.com/ggandor/leap.nvim) - A refined successor of Lightspeed, aiming to establish a widely accepted standard interface extension for moving around in Vim-like editors.


### PR DESCRIPTION
This repo has not been updated since `2020-09-10 14:04:30 UTC`.
Can @tjdevries confirm whether this repo is still intended for use?