### PR TITLE
Remove `madskjeldgaard/reaper-nvim`

### DIFF
--- a/README.md
+++ b/README.md
@@ -696,7 +696,6 @@ These colorschemes may not specialize in Tree-sitter directly but are written in
 - [ekickx/clipboard-image.nvim](https://github.com/ekickx/clipboard-image.nvim) - Neovim Lua plugin to paste image from clipboard.
 - [askfiy/nvim-picgo](https://github.com/askfiy/nvim-picgo) - A picgo-core-based Neovim plugin, written in Lua, that allows you to upload images to the image bed, which means you can view your images from anywhere on the internet.
 - [gwatcha/reaper-keys](https://github.com/gwatcha/reaper-keys) - Modal keybindings for Reaper DAW.
-- [madskjeldgaard/reaper-nvim](https://github.com/madskjeldgaard/reaper-nvim) - Remote control Reaper DAW from Neovim.
 - [davidgranstrom/scnvim](https://github.com/davidgranstrom/scnvim) - Neovim frontend for SuperCollider.
 
 ### Discord Rich Presence


### PR DESCRIPTION
This repo has not been updated since `2021-01-29 09:14:22 UTC`.
Can @madskjeldgaard confirm whether this repo is still intended for use?