### PR TITLE
Remove `AckslD/nvim-whichkey-setup.lua`

### DIFF
--- a/README.md
+++ b/README.md
@@ -754,7 +754,6 @@ These colorschemes may not specialize in Tree-sitter directly but are written in
 
 ### Keybinding
 
-- [AckslD/nvim-whichkey-setup.lua](https://github.com/AckslD/nvim-whichkey-setup.lua) - Plugin that wraps vim-which-key to simplify setup in Lua.
 - [folke/which-key.nvim](https://github.com/folke/which-key.nvim) - Neovim plugin that shows a popup with possible keybindings of the command you started typing.
 - [mrjones2014/legendary.nvim](https://github.com/mrjones2014/legendary.nvim) - Define your keymaps, commands, and autocommands as simple Lua tables, and create a legend for them at the same time, integrates with `which-key.nvim`.
 - [Iron-E/nvim-cartographer](https://github.com/Iron-E/nvim-cartographer) - a more convenient `:map`ping syntax for Lua environments.


### PR DESCRIPTION
This repo has not been updated since `2021-04-18 05:44:42 UTC`.
Can @AckslD confirm whether this repo is still intended for use?