### PR TITLE
Remove `gennaro-tedesco/boilit`

### DIFF
--- a/README.md
+++ b/README.md
@@ -798,7 +798,6 @@ These tools are used externally to Neovim to enhance the experience.
 
 ### Boilerplate
 
-- [gennaro-tedesco/boilit](https://github.com/gennaro-tedesco/boilit) - Create boilerplate structure for Neovim plugins.
 
 ## Vim
 


### PR DESCRIPTION
This repo has not been updated since `2021-04-17 13:31:27 UTC`.
Can @gennaro-tedesco confirm whether this repo is still intended for use?