### PR TITLE
Add `cappyzawa/trim.nvim`

### DIFF
--- a/README.md
+++ b/README.md
@@ -684,6 +684,7 @@ These colorschemes may not specialize in Tree-sitter directly but are written in
 - [mhartington/formatter.nvim](https://github.com/mhartington/formatter.nvim) - A format runner for Neovim written in Lua.
 - [lukas-reineke/lsp-format.nvim](https://github.com/lukas-reineke/lsp-format.nvim) - A wrapper around Neovims native LSP formatting.
 - [sbdchd/neoformat](https://github.com/sbdchd/neoformat) - A (Neo)vim plugin for formatting code.
+- [cappyzawa/trim.nvim](https://github.com/cappyzawa/trim.nvim) - This plugin trims trailing whitespace and lines.
 
 ### Web development
 


### PR DESCRIPTION
Checklist:

- [x] The plugin is specifically built for Neovim.
- [x] The lines end with a `.`. This is to conform to `awesome-list` linting and requirements.
- [x] It's not already on the list.
- [x] If it's a colorscheme, it supports treesitter syntax.
- [x] The title of the pull request is ```Add `username/repo` ``` when adding a new plugin.
- [x] Neovim is spelled as `Neovim` (not `nvim`, `NeoVim` or `neovim`), Lua is spelled as `Lua` (capitalized).
