### PR TITLE
Update `McAuleyPenney/tidy.nvim`

### DIFF
--- a/README.md
+++ b/README.md
@@ -673,7 +673,6 @@ These colorschemes may not specialize in Tree-sitter directly but are written in
 - [ethanholz/nvim-lastplace](https://github.com/ethanholz/nvim-lastplace) - Reopen files at your last edit position.
 - [Allendang/nvim-expand-expr](https://github.com/AllenDang/nvim-expand-expr) - Expand and repeat expression to multiple lines.
 - [h-hg/fcitx.nvim](https://github.com/h-hg/fcitx.nvim) - Switching and restoring fcitx state for each buffer separately.
-- [McAuleyPenney/tidy.nvim](https://github.com/McAuleyPenney/tidy.nvim) - Clear trailing whitespace and empty lines at end of file on every save.
 <!--lint ignore double-link-->
 - [echasnovski/mini.nvim#mini.trailspace](https://github.com/echasnovski/mini.nvim#minitrailspace) - Module of `mini.nvim` for automatic highlighting of trailing whitespace with functionality to remove it.
 - [filipdutescu/renamer.nvim](https://github.com/filipdutescu/renamer.nvim) - VS Code-like renaming UI for Neovim, written in Lua.
@@ -693,6 +692,7 @@ These colorschemes may not specialize in Tree-sitter directly but are written in
 - [lukas-reineke/lsp-format.nvim](https://github.com/lukas-reineke/lsp-format.nvim) - A wrapper around Neovims native LSP formatting.
 - [sbdchd/neoformat](https://github.com/sbdchd/neoformat) - A (Neo)vim plugin for formatting code.
 - [cappyzawa/trim.nvim](https://github.com/cappyzawa/trim.nvim) - This plugin trims trailing whitespace and lines.
+- [mcauley-penney/tidy.nvim](https://github.com/mcauley-penney/tidy.nvim) - Clear trailing whitespace and empty lines at end of file on every save. 
 
 ### Web development
 


### PR DESCRIPTION
Checklist:

- [x] The plugin is specifically built for Neovim.
- [x] The lines end with a `.`. This is to conform to `awesome-list` linting and requirements.
- [x] It's not already on the list.
It is already on the list but I'm not duplicating it or adding any new content. I'm moving it to the place it should probably be in, where there are similar plugins. I don't know if the `Formatting` section was around when I first added this to the list.

- [x] If it's a colorscheme, it supports treesitter syntax.
It is not a colorscheme

- [x] The title of the pull request is ```Add `username/repo` ``` when adding a new plugin.
I am not adding a new plugin

- [x] Neovim is spelled as `Neovim` (not `nvim`, `NeoVim` or `neovim`), Lua is spelled as `Lua` (capitalized).
I don't have `Neovim` or `Lua` in the description. The name of the plugin has ".nvim" in it in the same way other plugins do.
