### PR TITLE
Add `Saecki/crates.nvim`

### DIFF
--- a/README.md
+++ b/README.md
@@ -531,6 +531,7 @@ These colorschemes may not specialize in Tree-sitter directly but are written in
 ### Dependency management
 
 - [vuki656/package-info.nvim](https://github.com/vuki656/package-info.nvim) - Display latest package version as virtual text in package.json.
+- [Saecki/crates.nvim](https://github.com/Saecki/crates.nvim) -  Rust dependency management for `Cargo.toml`.
 
 ### Git
 


### PR DESCRIPTION
Checklist:

- [x] The plugin is specifically built for Neovim.
- [x] The lines end with a `.`. This is to conform to `awesome-list` linting and requirements.
- [x] It's not already on the list.
- [ ] If it's a colorscheme, it supports treesitter syntax.
- [x] The title of the pull request is ```Add `username/repo` ``` when adding a new plugin.
- [x] Neovim is spelled as `Neovim` (not `nvim`, `NeoVim` or `neovim`), Lua is spelled as `Lua` (capitalized).
