### PR TITLE
Add `lmburns/kimbox`

### DIFF
--- a/README.md
+++ b/README.md
@@ -359,6 +359,7 @@ Tree-sitter is a new system introduced in Neovim 0.5 that incrementally parses y
 - [kvrohit/rasmus.nvim](https://github.com/kvrohit/rasmus.nvim) - A dark color scheme for Neovim written in Lua ported from [rsms/sublime-theme](https://github.com/rsms/sublime-theme) theme.
 - [chrsm/paramount-ng.nvim](https://github.com/chrsm/paramount-ng.nvim) - A dark color scheme written using Lush. Treesitter supported.
 - [kaiuri/nvim-mariana](https://github.com/kaiuri/nvim-mariana) - Port of Sublime's Mariana Theme to Neovim for short attention span developers with Tree-sitter support.
+- [lmburns/kimbox](https://github.com/lmburns/kimbox) - A colorscheme with a dark background, and vibrant foreground that is centered around the color brown. A modification of [Kimbie Dark](https://marketplace.visualstudio.com/items?itemName=dnamsons.kimbie-dark-plus).
 
 #### Lua Colorscheme
 


### PR DESCRIPTION
Checklist:

- [x] The plugin is specifically built for Neovim.
- [x] The lines end with a `.`. This is to conform to `awesome-list` linting and requirements.
- [x] It's not already on the list.
- [x] If it's a colorscheme, it supports treesitter syntax.
- [x] The title of the pull request is ```Add `username/repo` ``` when adding a new plugin.
- [x] Neovim is spelled as `Neovim` (not `nvim`, `NeoVim` or `neovim`), Lua is spelled as `Lua` (capitalized).
