### PR TITLE
Add `altermo/vim-plugin-list`

### DIFF
--- a/README.md
+++ b/README.md
@@ -823,6 +823,7 @@ These tools are used externally to Neovim to enhance the experience.
 
 - [Vimawesome](https://vimawesome.com/) - Showcases various plugins for vim and has a [neovim tag](https://vimawesome.com/?q=tag:neovim) for other plugins targeting Neovim.
 - [awesome-vim](https://github.com/akrawchyk/awesome-vim#tools) - Short list of vim plugins and helpful guides.
+- [vim-plugin-list](https://github.com/altermo/vim-plugin-list) - List of vim and Neovim plugins.
 
 ## Resource
 


### PR DESCRIPTION
Checklist:

- [ ] The plugin is specifically built for Neovim.
- [x] The lines end with a `.`. This is to conform to `awesome-list` linting and requirements.
- [x] It's not already on the list.
- [x] If it's a colorscheme, it supports treesitter syntax.
- [x] The title of the pull request is ```Add `username/repo` ``` when adding a new plugin.
- [x] Neovim is spelled as `Neovim` (not `nvim`, `NeoVim` or `neovim`), Lua is spelled as `Lua` (capitalized).
