### PR TITLE
Add `Weissle/persistent-breakpoints.nvim`

### DIFF
--- a/README.md
+++ b/README.md
@@ -416,6 +416,7 @@ These colorschemes may not specialize in Tree-sitter directly but are written in
 - [sakhnik/nvim-gdb](https://github.com/sakhnik/nvim-gdb) - Thin wrapper for GDB, LLDB, PDB/PDB++ and BashDB.
 - [rcarriga/nvim-dap-ui](https://github.com/rcarriga/nvim-dap-ui) - A UI for nvim-dap.
 - [Pocco81/DAPInstall.nvim](https://github.com/Pocco81/DAPInstall.nvim) - A NeoVim plugin for managing several debuggers for Nvim-dap.
+- [Weissle/persistent-breakpoints.nvim](https://github.com/Weissle/persistent-breakpoints.nvim) - Persistent breakpoints for nvim-dap.
 
 ### Spellcheck
 


### PR DESCRIPTION
Checklist:

- [x] The plugin is specifically built for Neovim.
- [x] The lines end with a `.`. This is to conform to `awesome-list` linting and requirements.
- [x] It's not already on the list.
- [x] If it's a colorscheme, it supports treesitter syntax.
- [x] The title of the pull request is ```Add `username/repo` ``` when adding a new plugin.
- [x] Neovim is spelled as `Neovim` (not `nvim`, `NeoVim` or `neovim`), Lua is spelled as `Lua` (capitalized).
