### PR TITLE
Remove `rcarriga/vim-ultest`

### DIFF
--- a/README.md
+++ b/README.md
@@ -756,7 +756,6 @@ These colorschemes may not specialize in Tree-sitter directly but are written in
 
 ### Test
 
-- [rcarriga/vim-ultest](https://github.com/rcarriga/vim-ultest) - The ultimate testing plugin for Neovim.
 - [David-Kunz/jester](https://github.com/David-Kunz/jester) - A Neovim plugin to easily run and debug Jest tests.
 - [klen/nvim-test](https://github.com/klen/nvim-test) - A Neovim wrapper for running tests.
 - [nvim-neotest/neotest](https://github.com/nvim-neotest/neotest) - An extensible framework for interacting with tests within Neovim.


### PR DESCRIPTION
See their the message in the [README](https://github.com/rcarriga/vim-ultest#deprecation-warning)

Checklist:

- [x] ~The plugin is specifically built for Neovim.~
- [x] ~The lines end with a `.`. This is to conform to `awesome-list` linting and requirements.~
- [x] ~It's not already on the list.~
- [x] ~If it's a colorscheme, it supports treesitter syntax.~
- [x] ~The title of the pull request is ```Add `username/repo` ``` when adding a new plugin.~
- [x] Neovim is spelled as `Neovim` (not `nvim`, `NeoVim` or `neovim`), Lua is spelled as `Lua` (capitalized).
