### PR TITLE
Rename `norcalli/nvim-colorizer.lua` -> `NvChad/nvim-colorizer.lua`

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,7 +273,7 @@ Neovim supports a wide variety of UI's.
 
 ### Color
 
-- [norcalli/nvim-colorizer.lua](https://github.com/norcalli/nvim-colorizer.lua) - A high-performance color highlighter for Neovim which has no external dependencies!.
+- [NvChad/nvim-colorizer.lua](https://github.com/NvChad/nvim-colorizer.lua) - A high-performance color highlighter for Neovim which has no external dependencies!.
 - [sunjon/Shade.nvim](https://github.com/sunjon/Shade.nvim) - Shade is a Neovim plugin that dims your inactive windows, making it easier to see the active window at a glance.
 - [winston0410/range-highlight.nvim](https://github.com/winston0410/range-highlight.nvim) - An extremely lightweight plugin (~ 120loc) that highlights ranges you have entered in commandline.
 - [xiyaowong/nvim-transparent](https://github.com/xiyaowong/nvim-transparent) - Make your Neovim transparent.


### PR DESCRIPTION
https://github.com/norcalli/nvim-colorizer.lua is unmaintained, and [NvChad's fork](https://github.com/NvChad/nvim-colorizer.lua) is the most actively maintained fork.

Checklist:

- [x] The plugin is specifically built for Neovim.
- [x] The lines end with a `.`. This is to conform to `awesome-list` linting and requirements.
- [ ] It's not already on the list.
- [ ] If it's a colorscheme, it supports treesitter syntax.
- [ ] The title of the pull request is ```Add `username/repo` ``` when adding a new plugin.
- [x] Neovim is spelled as `Neovim` (not `nvim`, `NeoVim` or `neovim`), Lua is spelled as `Lua` (capitalized).
