### PR TITLE
Update nvim-startup.lua moved to sr.ht from github

### DIFF
--- a/README.md
+++ b/README.md
@@ -515,7 +515,7 @@ These colorschemes may not specialize in Tree-sitter directly but are written in
 - [goolord/alpha-nvim](https://github.com/goolord/alpha-nvim) - A fast and highly customizable greeter like [vim-startify](https://github.com/mhinz/vim-startify)/dashboard-nvim for Neovim.
 <!--lint ignore double-link-->
 - [echasnovski/mini.nvim#mini.starter](https://github.com/echasnovski/mini.nvim#ministarter) - Module of `mini.nvim` for start screen. Displayed items are fully customizable, item selection can be done using prefix query with instant visual feedback.
-- [henriquehbr/nvim-startup.lua](https://github.com/henriquehbr/nvim-startup.lua) - Displays Neovim startup time.
+- [henriquehbr/nvim-startup.lua](https://sr.ht/~henriquehbr/nvim-startup.lua) - Displays Neovim startup time.
 - [startup-nvim/startup.nvim](https://github.com/startup-nvim/startup.nvim) - The fully customizable greeter for neovim.
 
 ### Indent


### PR DESCRIPTION
The author of https://github.com/henriquehbr/nvim-startup.lua has migrated to https://sr.ht/~henriquehbr/nvim-startup.lua

Checklist:

- [ ] The plugin is specifically built for Neovim.
- [ ] The lines end with a `.`. This is to conform to `awesome-list` linting and requirements.
- [ ] It's not already on the list.
- [ ] If it's a colorscheme, it supports treesitter syntax.
- [ ] The title of the pull request is ```Add `username/repo` ``` when adding a new plugin.
- [ ] Neovim is spelled as `Neovim` (not `nvim`, `NeoVim` or `neovim`), Lua is spelled as `Lua` (capitalized).
