### PR TITLE
Add  `kaiuri/github-vscode-theme.nvim`

### DIFF
--- a/README.md
+++ b/README.md
@@ -369,8 +369,7 @@ Tree-sitter is a new system introduced in Neovim 0.5 that incrementally parses y
 - [meliora-theme/neovim](https://github.com/meliora-theme/neovim) - Warm and cozy theme for Neovim.
 - [Yazeed1s/minimal.nvim](https://github.com/yazeed1s/minimal.nvim) - Two tree-sitter supported colorschemes that are inspired by base16-tomorrow-night and monokai-pro.
 - [lewpoly/sherbet.nvim](https://github.com/lewpoly/sherbet.nvim) - A soothing colorscheme with support for popular plugins and tree-sitter.
-- [kaiuri/github-vscode-theme.nvim
-](https://github.com/kaiuri/github-vscode-theme.nvim) - Port of [GitHub's VS Code themes](https://github.com/primer/github-vscode-theme) to Neovim with Tree-sitter support.
+- [kaiuri/github-vscode-theme.nvim](https://github.com/kaiuri/github-vscode-theme.nvim) - Port of [GitHub's VS Code themes](https://github.com/primer/github-vscode-theme) to Neovim with Tree-sitter support.
 
 #### Lua Colorscheme
 

--- a/README.md
+++ b/README.md
@@ -369,6 +369,8 @@ Tree-sitter is a new system introduced in Neovim 0.5 that incrementally parses y
 - [meliora-theme/neovim](https://github.com/meliora-theme/neovim) - Warm and cozy theme for Neovim.
 - [Yazeed1s/minimal.nvim](https://github.com/yazeed1s/minimal.nvim) - Two tree-sitter supported colorschemes that are inspired by base16-tomorrow-night and monokai-pro.
 - [lewpoly/sherbet.nvim](https://github.com/lewpoly/sherbet.nvim) - A soothing colorscheme with support for popular plugins and tree-sitter.
+- [kaiuri/github-vscode-theme.nvim
+](https://github.com/kaiuri/github-vscode-theme.nvim) - Port of [GitHub's VS Code themes](https://github.com/primer/github-vscode-theme) to Neovim with Tree-sitter support.
 
 #### Lua Colorscheme
 


### PR DESCRIPTION
Checklist:

- [x] The plugin is specifically built for Neovim.
- [x] The lines end with a `.`. This is to conform to `awesome-list` linting and requirements.
- [x] It's not already on the list.
- [x] If it's a colorscheme, it supports treesitter syntax.
- [x] The title of the pull request is ```Add `username/repo` ``` when adding a new plugin.
- [x] Neovim is spelled as `Neovim` (not `nvim`, `NeoVim` or `neovim`), Lua is spelled as `Lua` (capitalized).
