### PR TITLE
Add `lcheylus/overlength.nvim`

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,6 +280,7 @@ Neovim supports a wide variety of UI's.
 - [folke/twilight.nvim](https://github.com/folke/twilight.nvim) - Dim inactive portions of the code you're editing using TreeSitter.
 - [koenverburg/peepsight.nvim](https://github.com/koenverburg/peepsight.nvim) - Focus only the function your cursor is in.
 - [ziontee113/color-picker.nvim](https://github.com/ziontee113/color-picker.nvim) - Plugin that lets users choose & modify RGB/HSL/HEX colors inside Neovim.
+* [lcheylus/overlength.nvim](https://github.com/lcheylus/overlength.nvim) - A small plugin to highlight too long lines.
 
 ### Colorscheme Creation
 
@@ -851,4 +852,3 @@ These tools are used externally to Neovim to enhance the experience.
 
 - [Neovimcraft](https://neovimcraft.com) - A site dedicated to searching for Neovim specific plugins and guides for building plugins in Lua.
 - [TWiN](https://this-week-in-neovim.org) - TWiN (this-week-in-neovim.org) is dedicated to providing weekly news about Neovim and its ecosystem.
-

--- a/README.md
+++ b/README.md
@@ -280,7 +280,7 @@ Neovim supports a wide variety of UI's.
 - [folke/twilight.nvim](https://github.com/folke/twilight.nvim) - Dim inactive portions of the code you're editing using TreeSitter.
 - [koenverburg/peepsight.nvim](https://github.com/koenverburg/peepsight.nvim) - Focus only the function your cursor is in.
 - [ziontee113/color-picker.nvim](https://github.com/ziontee113/color-picker.nvim) - Plugin that lets users choose & modify RGB/HSL/HEX colors inside Neovim.
-* [lcheylus/overlength.nvim](https://github.com/lcheylus/overlength.nvim) - A small plugin to highlight too long lines.
+- [lcheylus/overlength.nvim](https://github.com/lcheylus/overlength.nvim) - A small plugin to highlight too long lines.
 
 ### Colorscheme Creation
 


### PR DESCRIPTION
Checklist:

- [X] The plugin is specifically built for Neovim.
- [X] The lines end with a `.`. This is to conform to `awesome-list` linting and requirements.
- [X] It's not already on the list.
- [ ] If it's a colorscheme, it supports treesitter syntax.
- [X] The title of the pull request is ```Add `username/repo` ``` when adding a new plugin.
- [X] Neovim is spelled as `Neovim` (not `nvim`, `NeoVim` or `neovim`), Lua is spelled as `Lua` (capitalized).
