### PR TITLE
Remove `SmiteshP/nvim-gps`

### DIFF
--- a/README.md
+++ b/README.md
@@ -505,8 +505,7 @@ These colorschemes may not specialize in Tree-sitter directly but are written in
 
 ### Winbar and Statusline component
 
-- [SmiteshP/nvim-gps](https://github.com/SmiteshP/nvim-gps) - A simple statusline component that shows your current code context using Treesitter.
-- [SmiteshP/nvim-navic](https://github.com/SmiteshP/nvim-navic) - A simple statusline/winbar component that shows your current code context using LSP.
+- [SmiteshP/nvim-navic](https://github.com/SmiteshP/nvim-navic) - A simple statusline/winbar component that uses LSP to show your current code context.
 
 ### Cursorline
 


### PR DESCRIPTION
Remove [SmiteshP/nvim-gps](https://github.com/SmiteshP/nvim-gps) because of deprecation.
The author presents [SmiteshP/nvim-navic](https://github.com/SmiteshP/nvim-navic) as the successor of `nvim-gps`. Both are written by the same author. Thanks to @SmiteshP

---

Checklist:

- [x] The plugin is specifically built for Neovim.
- [x] The lines end with a `.`. This is to conform to `awesome-list` linting and requirements.
- [x] It's not already on the list.
- [x] If it's a colorscheme, it supports treesitter syntax.
- [x] The title of the pull request is ```Add `username/repo` ``` when adding a new plugin.
- [x] Neovim is spelled as `Neovim` (not `nvim`, `NeoVim` or `neovim`), Lua is spelled as `Lua` (capitalized).
