### PR TITLE
Add `ofirgall/goto-breakpoints.nvim`

### DIFF
--- a/README.md
+++ b/README.md
@@ -433,6 +433,7 @@ These colorschemes may not specialize in Tree-sitter directly but are written in
 - [rcarriga/nvim-dap-ui](https://github.com/rcarriga/nvim-dap-ui) - A UI for nvim-dap.
 - [Pocco81/DAPInstall.nvim](https://github.com/Pocco81/DAPInstall.nvim) - A Neovim plugin for managing several debuggers for Nvim-dap.
 - [Weissle/persistent-breakpoints.nvim](https://github.com/Weissle/persistent-breakpoints.nvim) - Persistent breakpoints for nvim-dap.
+- [ofirgall/goto-breakpoints.nvim](https://github.com/ofirgall/goto-breakpoints.nvim) - Cycle between breakpoints for nvim-dap.
 - [andrewferrier/debugprint.nvim](https://github.com/andrewferrier/debugprint.nvim) - Debugging in Neovim the print() way.
 
 ### Spellcheck


### PR DESCRIPTION
Checklist:

- [V] The plugin is specifically built for Neovim.
- [V] The lines end with a `.`. This is to conform to `awesome-list` linting and requirements.
- [V] It's not already on the list.
- [V] If it's a colorscheme, it supports treesitter syntax.
- [V] The title of the pull request is ```Add `username/repo` ``` when adding a new plugin.
- [V] Neovim is spelled as `Neovim` (not `nvim`, `NeoVim` or `neovim`), Lua is spelled as `Lua` (capitalized).
