### PR TITLE
Add `smzm/hydrovim`

### DIFF
--- a/README.md
+++ b/README.md
@@ -643,6 +643,7 @@ These colorschemes may not specialize in Tree-sitter directly but are written in
 - [jedrzejboczar/toggletasks.nvim](https://github.com/jedrzejboczar/toggletasks.nvim) - Task runner with JSON/YAML configs, using toggleterm.nvim and telescope.nvim.
 - [EthanJWright/vs-tasks.nvim](https://github.com/EthanJWright/vs-tasks.nvim) - Telescope picker for VSCode style tasks.
 - [stevearc/overseer.nvim](https://github.com/stevearc/overseer.nvim) - A task runner and job management plugin.
+- [smzm/hydrovim]([https://](https://github.com/smzm/hydrovim)) - Run python code inside Neovim.
 
 ### GitHub
 

--- a/README.md
+++ b/README.md
@@ -643,7 +643,7 @@ These colorschemes may not specialize in Tree-sitter directly but are written in
 - [jedrzejboczar/toggletasks.nvim](https://github.com/jedrzejboczar/toggletasks.nvim) - Task runner with JSON/YAML configs, using toggleterm.nvim and telescope.nvim.
 - [EthanJWright/vs-tasks.nvim](https://github.com/EthanJWright/vs-tasks.nvim) - Telescope picker for VSCode style tasks.
 - [stevearc/overseer.nvim](https://github.com/stevearc/overseer.nvim) - A task runner and job management plugin.
-- [smzm/hydrovim]([https://](https://github.com/smzm/hydrovim)) - Run python code inside Neovim.
+- [smzm/hydrovim](https://github.com/smzm/hydrovim) - Run python code inside Neovim.
 
 ### GitHub
 


### PR DESCRIPTION
Checklist:

- [ *] The plugin is specifically built for Neovim.
- [ *] The lines end with a `.`. This is to conform to `awesome-list` linting and requirements.
- [ *] It's not already on the list.
- [ *] If it's a colorscheme, it supports treesitter syntax.
- [ *] The title of the pull request is ```Add `username/repo` ``` when adding a new plugin.
- [* ] Neovim is spelled as `Neovim` (not `nvim`, `NeoVim` or `neovim`), Lua is spelled as `Lua` (capitalized).
