### PR TITLE
Add `ray-x/web-tools.nvim` & `ray-x/starry.nvim`

### DIFF
--- a/README.md
+++ b/README.md
@@ -323,7 +323,7 @@ Tree-sitter is a new system introduced in Neovim 0.5 that incrementally parses y
 - [Th3Whit3Wolf/space-nvim](https://github.com/Th3Whit3Wolf/space-nvim) - A spacemacs inspired dark and light colorscheme for Neovim.
 - [yonlu/omni.vim](https://github.com/yonlu/omni.vim) - Omni color scheme for Vim.
 - [ray-x/aurora](https://github.com/ray-x/aurora) - A 24-bit dark theme with Tree-sitter and LSP support.
-- [ray-x/starry.nvim](https://github.com/ray-x/starry.nvim) -  A collection of modern nvim colorschemes: material, moonlight, dracula (blood), monokai, mariana, emerald, earlysummer, middlenight_blue, darksolar.
+- [ray-x/starry.nvim](https://github.com/ray-x/starry.nvim) -  A collection of modern Neovim colorschemes: material, moonlight, dracula (blood), monokai, mariana, emerald, earlysummer, middlenight_blue, darksolar.
 - [tanvirtin/monokai.nvim](https://github.com/tanvirtin/monokai.nvim) - Monokai theme for Neovim written in Lua.
 - [savq/melange](https://github.com/savq/melange) - Dark color scheme for Neovim and Vim 🗡️.
 - [RRethy/nvim-base16](https://github.com/RRethy/nvim-base16) - Neovim plugin for building base16 colorschemes. Includes support for Treesitter and LSP highlight groups.
@@ -464,7 +464,7 @@ These colorschemes may not specialize in Tree-sitter directly but are written in
 <!--lint ignore double-link-->
 - [echasnovski/mini.nvim#mini.test](https://github.com/echasnovski/mini.nvim#minitest) - Module of `mini.nvim` with framework for writing extensive Neovim plugin tests. Supports hierarchical tests, hooks, parametrization, filtering, screen tests, "busted-style" emulation, customizable reporters, and more.
 - [miversen33/import.nvim](https://github.com/miversen33/import.nvim) - A safe require replacement with niceties.
-- [ray-x/guihua.lua](https://github.com/ray-x/guihua.lua) - A lua UI and util library. Includes a fzy search bar, list view and a tree view.
+- [ray-x/guihua.lua](https://github.com/ray-x/guihua.lua) - A Lua UI and util library. Includes a fzy search bar, list view and a tree view.
 
 ### Fennel
 
@@ -658,7 +658,7 @@ These colorschemes may not specialize in Tree-sitter directly but are written in
 - [kevinhwang91/nvim-hlslens](https://github.com/kevinhwang91/nvim-hlslens) - Helps you better glance searched information, seamlessly jump matched instances.
 - [rktjmp/highlight-current-n.nvim](https://github.com/rktjmp/highlight-current-n.nvim) - Highlights the current /, ? or \* match under your cursor when pressing n or N and gets out of the way afterwards.
 - [gaborvecsei/memento.nvim](https://github.com/gaborvecsei/memento.nvim) - Keeps track of your visited file history after a buffer is closed. Reopen files more easily.
-- [ray-x/sad.nvim](https://github.com/ray-x/sad.nvim) - Space Age seD in neovim. Batch file edit tool for neovim, a neovim wrapper for [sad](https://github.com/ms-jpq/sad)
+- [ray-x/sad.nvim](https://github.com/ray-x/sad.nvim) - Space Age seD in neovim. Batch file edit tool for Neovim, a neovim wrapper for [sad](https://github.com/ms-jpq/sad)
 
 
 ### Scrollbar

--- a/README.md
+++ b/README.md
@@ -741,7 +741,7 @@ These colorschemes may not specialize in Tree-sitter directly but are written in
 ### Web development
 
 - [NTBBloodbath/rest.nvim](https://github.com/NTBBloodbath/rest.nvim) - A fast Neovim http client written in Lua.
-- [ray-x/web-tools.nvim](https://github.com/ray-x/web-tools.nvim) - Launch a local development server with live reload feature for static & dynamic pages, http&ccs tag rename with LSP.
+- [ray-x/web-tools.nvim](https://github.com/ray-x/web-tools.nvim) - Launch a local development server with live reload feature for static & dynamic pages, HTTP & CSS tag rename with LSP.
 
 ### Media
 

--- a/README.md
+++ b/README.md
@@ -464,7 +464,7 @@ These colorschemes may not specialize in Tree-sitter directly but are written in
 <!--lint ignore double-link-->
 - [echasnovski/mini.nvim#mini.test](https://github.com/echasnovski/mini.nvim#minitest) - Module of `mini.nvim` with framework for writing extensive Neovim plugin tests. Supports hierarchical tests, hooks, parametrization, filtering, screen tests, "busted-style" emulation, customizable reporters, and more.
 - [miversen33/import.nvim](https://github.com/miversen33/import.nvim) - A safe require replacement with niceties.
-- [ray-x/guihua.lua](https://github.com/ray-x/guihua.lua) - A Lua UI and util library. Includes a fzy search bar, list view and a tree view.
+- [ray-x/guihua.lua](https://github.com/ray-x/guihua.lua) - A Lua UI library. Includes a fzy search bar, list view and tree view modules.
 
 ### Fennel
 

--- a/README.md
+++ b/README.md
@@ -658,7 +658,7 @@ These colorschemes may not specialize in Tree-sitter directly but are written in
 - [kevinhwang91/nvim-hlslens](https://github.com/kevinhwang91/nvim-hlslens) - Helps you better glance searched information, seamlessly jump matched instances.
 - [rktjmp/highlight-current-n.nvim](https://github.com/rktjmp/highlight-current-n.nvim) - Highlights the current /, ? or \* match under your cursor when pressing n or N and gets out of the way afterwards.
 - [gaborvecsei/memento.nvim](https://github.com/gaborvecsei/memento.nvim) - Keeps track of your visited file history after a buffer is closed. Reopen files more easily.
-- [ray-x/sad.nvim](https://github.com/ray-x/sad.nvim) - Space Age seD in neovim. Batch file edit tool for Neovim, a neovim wrapper for [sad](https://github.com/ms-jpq/sad)
+- [ray-x/sad.nvim](https://github.com/ray-x/sad.nvim) - Space Age seD in neovim. Batch file edit tool for Neovim, a wrapper for [sad](https://github.com/ms-jpq/sad)
 
 
 ### Scrollbar
@@ -862,4 +862,6 @@ These tools are used externally to Neovim to enhance the experience.
 - [vim-plugin-list](https://github.com/altermo/vim-plugin-list) - List of vim and Neovim plugins.
 
 ## Resource
- [TWiN](https://this-week-in-neovim.org) - TWiN (this-week-in-neovim.org) is dedicated to providing weekly news about Neovim and its ecosystem.
+
+- [Neovimcraft](https://neovimcraft.com) - A site dedicated to searching for Neovim specific plugins and guides for building plugins in Lua.
+- [TWiN](https://this-week-in-neovim.org) - TWiN (this-week-in-neovim.org) is dedicated to providing weekly news about Neovim and its ecosystem.

--- a/README.md
+++ b/README.md
@@ -464,7 +464,7 @@ These colorschemes may not specialize in Tree-sitter directly but are written in
 <!--lint ignore double-link-->
 - [echasnovski/mini.nvim#mini.test](https://github.com/echasnovski/mini.nvim#minitest) - Module of `mini.nvim` with framework for writing extensive Neovim plugin tests. Supports hierarchical tests, hooks, parametrization, filtering, screen tests, "busted-style" emulation, customizable reporters, and more.
 - [miversen33/import.nvim](https://github.com/miversen33/import.nvim) - A safe require replacement with niceties.
-- [ray-x/guihua.lua](https://github.com/ray-x/guihua.lua) - A lua UI and util library. Include a fzy search bar, list view and a tree view.
+- [ray-x/guihua.lua](https://github.com/ray-x/guihua.lua) - A lua UI and util library. Includes a fzy search bar, list view and a tree view.
 
 ### Fennel
 

--- a/README.md
+++ b/README.md
@@ -323,6 +323,7 @@ Tree-sitter is a new system introduced in Neovim 0.5 that incrementally parses y
 - [Th3Whit3Wolf/space-nvim](https://github.com/Th3Whit3Wolf/space-nvim) - A spacemacs inspired dark and light colorscheme for Neovim.
 - [yonlu/omni.vim](https://github.com/yonlu/omni.vim) - Omni color scheme for Vim.
 - [ray-x/aurora](https://github.com/ray-x/aurora) - A 24-bit dark theme with Tree-sitter and LSP support.
+- [ray-x/starry.nvim](https://github.com/ray-x/starry.nvim) -  A collection of modern nvim colorschemes: material, moonlight, dracula (blood), monokai, mariana, emerald, earlysummer, middlenight_blue, darksolar.
 - [tanvirtin/monokai.nvim](https://github.com/tanvirtin/monokai.nvim) - Monokai theme for Neovim written in Lua.
 - [savq/melange](https://github.com/savq/melange) - Dark color scheme for Neovim and Vim 🗡️.
 - [RRethy/nvim-base16](https://github.com/RRethy/nvim-base16) - Neovim plugin for building base16 colorschemes. Includes support for Treesitter and LSP highlight groups.
@@ -463,6 +464,7 @@ These colorschemes may not specialize in Tree-sitter directly but are written in
 <!--lint ignore double-link-->
 - [echasnovski/mini.nvim#mini.test](https://github.com/echasnovski/mini.nvim#minitest) - Module of `mini.nvim` with framework for writing extensive Neovim plugin tests. Supports hierarchical tests, hooks, parametrization, filtering, screen tests, "busted-style" emulation, customizable reporters, and more.
 - [miversen33/import.nvim](https://github.com/miversen33/import.nvim) - A safe require replacement with niceties.
+- [ray-x/guihua.lua](https://github.com/ray-x/guihua.lua) - A lua UI and util library. Include a fzy search bar, list view and a tree view.
 
 ### Fennel
 
@@ -656,6 +658,8 @@ These colorschemes may not specialize in Tree-sitter directly but are written in
 - [kevinhwang91/nvim-hlslens](https://github.com/kevinhwang91/nvim-hlslens) - Helps you better glance searched information, seamlessly jump matched instances.
 - [rktjmp/highlight-current-n.nvim](https://github.com/rktjmp/highlight-current-n.nvim) - Highlights the current /, ? or \* match under your cursor when pressing n or N and gets out of the way afterwards.
 - [gaborvecsei/memento.nvim](https://github.com/gaborvecsei/memento.nvim) - Keeps track of your visited file history after a buffer is closed. Reopen files more easily.
+- [ray-x/sad.nvim](https://github.com/ray-x/sad.nvim) - Space Age seD in neovim. Batch file edit tool for neovim, a neovim wrapper for [sad](https://github.com/ms-jpq/sad)
+
 
 ### Scrollbar
 
@@ -737,6 +741,7 @@ These colorschemes may not specialize in Tree-sitter directly but are written in
 ### Web development
 
 - [NTBBloodbath/rest.nvim](https://github.com/NTBBloodbath/rest.nvim) - A fast Neovim http client written in Lua.
+- [ray-x/web-tools.nvim](https://github.com/ray-x/web-tools.nvim) - Launch a local development server with live reload feature for static & dynamic pages, http&ccs tag rename with LSP.
 
 ### Media
 
@@ -857,6 +862,4 @@ These tools are used externally to Neovim to enhance the experience.
 - [vim-plugin-list](https://github.com/altermo/vim-plugin-list) - List of vim and Neovim plugins.
 
 ## Resource
-
-- [Neovimcraft](https://neovimcraft.com) - A site dedicated to searching for Neovim specific plugins and guides for building plugins in Lua.
-- [TWiN](https://this-week-in-neovim.org) - TWiN (this-week-in-neovim.org) is dedicated to providing weekly news about Neovim and its ecosystem.
+ [TWiN](https://this-week-in-neovim.org) - TWiN (this-week-in-neovim.org) is dedicated to providing weekly news about Neovim and its ecosystem.


### PR DESCRIPTION
Checklist:

- [x] The plugin is specifically built for Neovim.
- [x] The lines end with a `.`. This is to conform to `awesome-list` linting and requirements.
- [x] It's not already on the list.
- [x] If it's a colorscheme, it supports treesitter syntax.
- [x] The title of the pull request is ```Add `username/repo` ``` when adding a new plugin.
- [x] Neovim is spelled as `Neovim` (not `nvim`, `NeoVim` or `neovim`), Lua is spelled as `Lua` (capitalized).
