### PR TITLE
Add `potamides/pantran.nvim`

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@
   - [Tmux](#tmux)
   - [Remote Development](#remote-development)
   - [Split and Window](#split-and-window)
+  - [Machine Translation](#machine-translation)
 - [External](#external)
   - [Version Manager](#version-manager)
   - [Boilerplate](#boilerplate)
@@ -837,6 +838,9 @@ These colorschemes may not specialize in Tree-sitter directly but are written in
 - [sindrets/winshift.nvim](https://github.com/sindrets/winshift.nvim) - Rearrange your windows with ease.
 - [beauwilliams/focus.nvim](https://github.com/beauwilliams/focus.nvim) - Auto-Focusing and Auto-Resizing Splits/Windows for Neovim written in Lua! Vim splits on steroids.
 - [luukvbaal/stabilize.nvim](https://github.com/luukvbaal/stabilize.nvim) - Stabilized window content on window open/close events.
+
+### Machine Translation
+- [potamides/pantran.nvim](https://github.com/potamides/pantran.nvim) - Use your favorite machine translation engines without having to leave your favorite editor.
 
 ## External
 


### PR DESCRIPTION
Checklist:

- [x] The plugin is specifically built for Neovim.
- [x] The lines end with a `.`. This is to conform to `awesome-list` linting and requirements.
- [x] It's not already on the list.
- [x] If it's a colorscheme, it supports treesitter syntax.
- [x] The title of the pull request is ```Add `username/repo` ``` when adding a new plugin.
- [x] Neovim is spelled as `Neovim` (not `nvim`, `NeoVim` or `neovim`), Lua is spelled as `Lua` (capitalized).
