### PR TITLE
lua-dev.nvim

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ Neovim supports a wide variety of UI's.
 - [ojroques/nvim-lspfuzzy](https://github.com/ojroques/nvim-lspfuzzy) - A small plugin to make the LSP client use FZF.
 - [gfanto/fzf-lsp.nvim](https://github.com/gfanto/fzf-lsp.nvim) - Enable the power of fzf fuzzy search for the Neovim built in lsp.
 - [ray-x/lsp_signature.nvim](https://github.com/ray-x/lsp_signature.nvim) - Lsp signature hint when you type.
+- [folke/lua-dev.nvim](https://github.com/folke/lua-dev.nvim) - Dev setup for init.Lua and plugin development with full signature help.docs and completion for the Neovim Lua api.
 - [smjonas/inc-rename.nvim](https://github.com/smjonas/inc-rename.nvim) - Provides an incremental LSP rename command based on Neovim's command-preview feature.
 - [rmagatti/goto-preview](https://github.com/rmagatti/goto-preview) - Previewing native LSP's goto definition calls in floating windows.
 - [nanotee/sqls.nvim](https://github.com/nanotee/sqls.nvim) - Sqls (sql database connection plugin + LSP client) plugin for Neovim.


### PR DESCRIPTION
Checklist:

- [ x ] The plugin is specifically built for Neovim.
- [ x ] The lines end with a `.`. This is to conform to `awesome-list` linting and requirements.
- [ x ] It's not already on the list.
- [ ] If it's a colorscheme, it supports treesitter syntax.
- [ x ] The title of the pull request is ```Add `username/repo` ``` when adding a new plugin.
- [ x ] Neovim is spelled as `Neovim` (not `nvim`, `NeoVim` or `neovim`), Lua is spelled as `Lua` (capitalized).
