### PR TITLE
Add `xuhdev/vim-latex-live-preview`

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,6 +205,7 @@ You can find them listed on the [Neovim wiki](https://github.com/neovim/neovim/w
 - [frabjous/knap](https://github.com/frabjous/knap) - Plugin for creating automatic updating-as-you-type previews for markdown, LaTeX and other documents.
 - [jbyuki/carrot.nvim](https://github.com/jbyuki/carrot.nvim) - Markdown evaluator for Neovim Lua code blocks.
 - [AckslD/nvim-FeMaco.lua](https://github.com/AckslD/nvim-FeMaco.lua) - Catalyze your Fenced Markdown Code-block editing.
+- [xuhdev/vim-latex-live-preview](https://github.com/xuhdev/vim-latex-live-preview) - Live markdown preview as PDF
 
 ### Language
 


### PR DESCRIPTION
Checklist:

- [x] The plugin is specifically built for Neovim.
- [ ] The lines end with a `.`. This is to conform to `awesome-list` linting and requirements.
- [x] It's not already on the list.
- [x] The title of the pull request is ```Add `username/repo` ``` when adding a new plugin.
- [x] Neovim is spelled as `Neovim` (not `nvim`, `NeoVim` or `neovim`), Vim is spelled as `Vim` (capitalized), Lua is spelled as `Lua` (capitalized).
- [ ] If it's a colorscheme, it supports treesitter syntax.
