### PR TITLE
Add `smjonas/live-command.nvim`

### DIFF
--- a/README.md
+++ b/README.md
@@ -690,6 +690,7 @@ These colorschemes may not specialize in Tree-sitter directly but are written in
 - [h-hg/fcitx.nvim](https://github.com/h-hg/fcitx.nvim) - Switching and restoring fcitx state for each buffer separately.
 - [keaising/im-select.nvim](https://github.com/keaising/im-select.nvim) - Switching and restoring input method automatically depends on Neovim's edit mode.
 - [echasnovski/mini.nvim#mini.trailspace](https://github.com/echasnovski/mini.nvim/blob/main/readmes/mini-trailspace.md) - Module of `mini.nvim` for automatic highlighting of trailing whitespace with functionality to remove it.
+- [smjonas/live-command.nvim](https://github.com/smjonas/live-command.nvim) - Text editing in Neovim with immediate visual feedback: preview commands such as `:norm`, `:g`, macros and more.
 - [filipdutescu/renamer.nvim](https://github.com/filipdutescu/renamer.nvim) - VS Code-like renaming UI for Neovim, written in Lua.
 - [gbprod/cutlass.nvim](https://github.com/gbprod/cutlass.nvim) - Plugin that adds a 'cut' operation separate from 'delete'.
 - [gbprod/substitute.nvim](https://github.com/gbprod/substitute.nvim) - Neovim plugin introducing a new operator motions to quickly replace and exchange text.


### PR DESCRIPTION
Checklist:

- [X] The plugin is specifically built for Neovim.
- [X] The lines end with a `.`. This is to conform to `awesome-list` linting and requirements.
- [X] It's not already on the list.
- [X] The title of the pull request is ```Add `username/repo` ``` when adding a new plugin.
- [X] Neovim is spelled as `Neovim` (not `nvim`, `NeoVim` or `neovim`), Vim is spelled as `Vim` (capitalized), Lua is spelled as `Lua` (capitalized).
- [ ] If it's a colorscheme, it supports treesitter syntax.
