### PR TITLE
Add `samodostal/image.nvim` & `adelarsq/image_preview.nvim`

### DIFF
--- a/README.md
+++ b/README.md
@@ -464,6 +464,8 @@ These colorschemes may not specialize in Tree-sitter directly but are written in
 - [andweeb/presence.nvim](https://github.com/andweeb/presence.nvim) - Fast and lite Discord Rich Presence plugin for Neovim written in Lua.
 - [Chaitanyabsrip/present.nvim](https://github.com/Chaitanyabsprip/present.nvim) - A Presentation plugin written for Neovim in Lua.
 - [krady21/compiler-explorer.nvim](https://github.com/krady21/compiler-explorer.nvim) - Async Lua plugin for interacting with [compiler-explorer](https://godbolt.org/).
+- [samodostal/image.nvim](https://github.com/samodostal/image.nvim) - Image Viewer as ASCII Art.
+- [adelarsq/image_preview.nvim](https://github.com/adelarsq/image_preview.nvim) - Neovim plugin for image previews. Depends on terminal Image Protocol support.
 
 ### Note taking
 

--- a/README.md
+++ b/README.md
@@ -465,7 +465,7 @@ These colorschemes may not specialize in Tree-sitter directly but are written in
 - [Chaitanyabsrip/present.nvim](https://github.com/Chaitanyabsprip/present.nvim) - A Presentation plugin written for Neovim in Lua.
 - [krady21/compiler-explorer.nvim](https://github.com/krady21/compiler-explorer.nvim) - Async Lua plugin for interacting with [compiler-explorer](https://godbolt.org/).
 - [samodostal/image.nvim](https://github.com/samodostal/image.nvim) - Image Viewer as ASCII Art.
-- [adelarsq/image_preview.nvim](https://github.com/adelarsq/image_preview.nvim) - Neovim plugin for image previews. Depends on terminal Image Protocol support.
+- [adelarsq/image_preview.nvim](https://github.com/adelarsq/image_preview.nvim) - Image preview based on terminal's Image Protocol support.
 
 ### Note taking
 


### PR DESCRIPTION
Add plugins samodostal/image.nvim and adelarsq/image_preview.nvim.

Checklist:

- [x] The plugin is specifically built for Neovim.
- [x] The lines end with a `.`. This is to conform to `awesome-list` linting and requirements.
- [x] It's not already on the list.
- [x] The title of the pull request is ```Add `username/repo` ``` when adding a new plugin.
- [x] Neovim is spelled as `Neovim` (not `nvim`, `NeoVim` or `neovim`), Vim is spelled as `Vim` (capitalized), Lua is spelled as `Lua` (capitalized).
~- [] If it's a colorscheme, it supports treesitter syntax.~
