### PR TITLE
Rename `andersevenrud/compe-tmux`

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ You can find them listed on the [Neovim wiki](https://github.com/neovim/neovim/w
   - [hrsh7th/cmp-nvim-lua](https://github.com/hrsh7th/cmp-nvim-lua) - A nvim-cmp source for the Neovim Lua API.
   - [lukas-reineke/cmp-rg](https://github.com/lukas-reineke/cmp-rg) - A nvim-cmp source for Ripgrep.
   - [f3fora/cmp-spell](https://github.com/f3fora/cmp-spell) - A nvim-cmp source for vim's spellsuggest.
-  - [andersevenrud/compe-tmux](https://github.com/andersevenrud/compe-tmux) - A nvim-cmp source for Tmux.
+  - [andersevenrud/cmp-tmux](https://github.com/andersevenrud/cmp-tmux) - A nvim-cmp source for Tmux.
   - [David-Kunz/cmp-npm](https://github.com/David-Kunz/cmp-npm) - A nvim-cmp source for NPM.
   - [lukas-reineke/cmp-under-comparator](https://github.com/lukas-reineke/cmp-under-comparator) - A nvim-cmp function for better sorting.
   - [zbirenbaum/copilot-cmp](https://github.com/zbirenbaum/copilot-cmp) - A nvim-cmp source for GitHub copilot.


### PR DESCRIPTION
This was changed to `andersevenrud/cmp-tmux` after compe deprecation.

The compe source is now located at https://github.com/andersevenrud/cmp-tmux/tree/compe

Checklist:

- [x] The plugin is specifically built for Neovim.
- [x] The lines end with a `.`. This is to conform to `awesome-list` linting and requirements.
- [x] It's not already on the list.
- [ ] ~~The title of the pull request is ```Add `username/repo` ``` when adding a new plugin.~~
- [ ] ~~Neovim is spelled as `Neovim` (not `nvim`, `NeoVim` or `neovim`), Vim is spelled as `Vim` (capitalized), Lua is spelled as `Lua` (capitalized).~~
- [ ] ~~If it's a colorscheme, it supports treesitter syntax.~~
