### PR TITLE
Add `hkupty/iron.nvim`

### DIFF
--- a/README.md
+++ b/README.md
@@ -573,7 +573,7 @@ These colorschemes may not specialize in Tree-sitter directly but are written in
 - [smzm/hydrovim](https://github.com/smzm/hydrovim) - Run python code inside Neovim.
 - [desdic/greyjoy.nvim](https://github.com/desdic/greyjoy.nvim) - A modular task runner for Makefiles, vscode tasks, kitchen etc.
 - [Shatur/neovim-tasks](https://github.com/Shatur/neovim-tasks) - A stateful task manager focused on integration with build systems.
-- [hkupty/iron.nvim](https://github.com/hkupty/iron.nvim) - Interactive REPLs of over 30 languages embedded in Neovim
+- [hkupty/iron.nvim](https://github.com/hkupty/iron.nvim) - Interactive REPLs of over 30 languages embedded in Neovim.
 
 ### Neovim Lua Development
 

--- a/README.md
+++ b/README.md
@@ -573,6 +573,7 @@ These colorschemes may not specialize in Tree-sitter directly but are written in
 - [smzm/hydrovim](https://github.com/smzm/hydrovim) - Run python code inside Neovim.
 - [desdic/greyjoy.nvim](https://github.com/desdic/greyjoy.nvim) - A modular task runner for Makefiles, vscode tasks, kitchen etc.
 - [Shatur/neovim-tasks](https://github.com/Shatur/neovim-tasks) - A stateful task manager focused on integration with build systems.
+- [hkupty/iron.nvim](https://github.com/hkupty/iron.nvim) - Interactive REPLs of over 30 languages embedded in Neovim
 
 ### Neovim Lua Development
 


### PR DESCRIPTION
Checklist:

- [x ] The plugin is specifically built for Neovim.
- [x ] The lines end with a `.`. This is to conform to `awesome-list` linting and requirements.
- [ x] It's not already on the list.
- [ x] The title of the pull request is ```Add `username/repo` ``` when adding a new plugin.
- [ x] Neovim is spelled as `Neovim` (not `nvim`, `NeoVim` or `neovim`), Vim is spelled as `Vim` (capitalized), Lua is spelled as `Lua` (capitalized).
- [ ] If it's a colorscheme, it supports treesitter syntax.
