### PR TITLE
Update `bluz71/vim-nightfly-colors` & `bluz71/vim-moonfly-colors`

### DIFF
--- a/README.md
+++ b/README.md
@@ -311,8 +311,8 @@ Tree-sitter is a new system introduced in Neovim 0.5 that incrementally parses y
 - [tomasiser/vim-code-dark](https://github.com/tomasiser/vim-code-dark) - A dark color scheme heavily inspired by the look of the Dark+ scheme of Visual Studio Code.
 - [Mofiqul/vscode.nvim](https://github.com/Mofiqul/vscode.nvim) - A Lua port of vim-code-dark colorscheme for Neovim with vscode light and dark theme.
 - [marko-cerovac/material.nvim](https://github.com/marko-cerovac/material.nvim) - Material.nvim is a highly configurable colorscheme written in Lua and based on the material palette.
-- [bluz71/vim-nightfly-guicolors](https://github.com/bluz71/vim-nightfly-guicolors) - Nightfly is a dark GUI color scheme heavily inspired by Sarah Drasner's Night Owl theme.
-- [bluz71/vim-moonfly-colors](https://github.com/bluz71/vim-moonfly-colors) - Moonfly is a dark color scheme with Tree-sitter support.
+- [bluz71/vim-nightfly-colors](https://github.com/bluz71/vim-nightfly-colors) - A dark midnight colorscheme with modern Neovim support including Tree-sitter.
+- [bluz71/vim-moonfly-colors](https://github.com/bluz71/vim-moonfly-colors) - A dark charcoal colorscheme with modern Neovim support including Tree-sitter.
 - [ChristianChiarulli/nvcode-color-schemes.vim](https://github.com/ChristianChiarulli/nvcode-color-schemes.vim) - Nvcode, onedark, nord colorschemes with Tree-sitter support.
 - [folke/tokyonight.nvim](https://github.com/folke/tokyonight.nvim) - A clean, dark and light Neovim theme written in Lua, with support for LSP, Tree-sitter and lots of plugins.
 - [sainnhe/sonokai](https://github.com/sainnhe/sonokai) - High Contrast & Vivid Color Scheme based on Monokai Pro.


### PR DESCRIPTION
Hello, author of `nightfly` and `moonfly` colorschemes speaking. Both these colorschemes, which have long supported Tree-sitter, have been listed here (for quite a while). Many thanks for that.

This PR simply updates the existing section with more appropriate taglines and well as taking into account that the `nightfly` theme has been slightly renamed from `vim-nightfly-guicolors` to `vim-nightfly-colors`.

Also note, don't let the `vim-` prefix trick anyone; both these themes fully support Neovim (e.g. Treesitter, Diagnostic, Telescope, NvimTree, etc).

Checklist:

- [x] If it's a colorscheme, it supports treesitter syntax.