### PR TITLE
Remove `lewis6991/spellsitter.nvim`

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,7 +208,6 @@ You can find them listed on the [Neovim wiki](https://github.com/neovim/neovim/w
 
 ### Language
 
-- [lewis6991/spellsitter.nvim](https://github.com/lewis6991/spellsitter.nvim) - Enable Neovim's spell checker with tree-sitter.
 - [potamides/pantran.nvim](https://github.com/potamides/pantran.nvim) - Translate your text with an interactive translation window.
 
 ### Syntax


### PR DESCRIPTION
This plugin has been merged into the official Neovim codebase. See https://github.com/lewis6991/spellsitter.nvim/blob/master/README.md#notice

Checklist:

- [x] The plugin is specifically built for Neovim, or if it's a colorscheme, it supports treesitter syntax.
- [x] The lines end with a `.`. This is to conform to `awesome-list` linting and requirements.
- [ ] It's not already on the list.
- [x] The title of the pull request is ```Add/Update/Remove `username/repo` ``` when adding a new plugin.
- [x] The description doesn't start with `A Neovim plugin for..`, or `A plugin for..`.
- [ ] The description doesn't mention that it's a Neovim plugin, it's obvious from the rest of the document.
- [x] Neovim is spelled as `Neovim` (not `nvim`, `NeoVim` or `neovim`), Vim is spelled as `Vim` (capitalized), Lua is spelled as `Lua` (capitalized).
