### PR TITLE
Add Highlight section

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@
     - [Tabline](#tabline)
     - [Winbar](#winbar)
     - [Cursorline](#cursorline)
+  - [Highlight](#highlight)    
   - [Startup](#startup)
   - [Icon](#icon)
   - [Media](#media)
@@ -446,6 +447,10 @@ These colorschemes may not specialize in Tree-sitter directly but are written in
 - [echasnovski/mini.nvim#mini.cursorword](https://github.com/echasnovski/mini.nvim/blob/main/readmes/mini-cursorword.md) - Module of `mini.nvim` for automatic highlighting of word under cursor (displayed after customizable delay).
 - [melkster/modicator.nvim](https://github.com/melkster/modicator.nvim) - Cursor line number mode indicator. Changes the `CursorLineNr` highlight based on Vim mode.
 
+### Highlight
+
+- ['azabiong/vim-highlighter'](https://github.com/azabiong/vim-highlighter) - Highlight words and expressions.
+- ['t9md/vim-quickhl'](https://github.com/t9md/vim-quickhl) - Quickly highlight &lt;cword&gt; or visually selected word.
 
 ### Startup
 


### PR DESCRIPTION
Checklist:

- [ ] The plugin is specifically built for Neovim, or if it's a colorscheme, it supports treesitter syntax.
> No, it's a Vim plugins, but I have not find Neovim alternatives.
- [x] The lines end with a `.`. This is to conform to `awesome-list` linting and requirements.
- [x] It's not already on the list.
- [x] The title of the pull request is ```Add/Update/Remove `username/repo` ``` when adding a new plugin.
- [x] The description doesn't start with `A Neovim plugin for..`, or `A plugin for..`.
- [x] The description doesn't mention that it's a Neovim plugin, it's obvious from the rest of the document.
- [x] Neovim is spelled as `Neovim` (not `nvim`, `NeoVim` or `neovim`), Vim is spelled as `Vim` (capitalized), Lua is spelled as `Lua` (capitalized).
