### PR TITLE
Add `phaazon/mind.nvim`

### DIFF
--- a/README.md
+++ b/README.md
@@ -494,6 +494,7 @@ These colorschemes may not specialize in Tree-sitter directly but are written in
 - [epwalsh/obsidian.nvim](https://github.com/epwalsh/obsidian.nvim) - Plugin for Obsidian, written in Lua.
 - [jghauser/papis.nvim](https://github.com/jghauser/papis.nvim) - Manage your bibliography from within your favourite editor.
 - [ostralyan/scribe.nvim](https://github.com/ostralyan/scribe.nvim) - Take notes, easily.
+- [phaazon/mind.nvim](https://github.com/phaazon/mind.nvim) - The power of trees at your fingertips.
 
 ### Utility
 


### PR DESCRIPTION
Checklist:

- [x] The plugin is specifically built for Neovim, or if it's a colorscheme, it supports treesitter syntax.
- [X] The lines end with a `.`. This is to conform to `awesome-list` linting and requirements.
- [X] It's not already on the list.
- [X] The title of the pull request is ```Add/Update/Remove `username/repo` ``` when adding a new plugin.
- [X] The description doesn't start with `A Neovim plugin for..`, or `A plugin for..`.
- [X] The description doesn't mention that it's a Neovim plugin, it's obvious from the rest of the document.
- [X] Neovim is spelled as `Neovim` (not `nvim`, `NeoVim` or `neovim`), Vim is spelled as `Vim` (capitalized), Lua is spelled as `Lua` (capitalized).
