### PR TITLE
Add `chrisgrieser/nvim-genghis` and `chrisgrieser/nvim-recorder`

### DIFF
--- a/README.md
+++ b/README.md
@@ -532,8 +532,8 @@ These colorschemes may not specialize in Tree-sitter directly but are written in
 - [numToStr/BufOnly.nvim](https://github.com/numToStr/BufOnly.nvim) - Lua/Neovim port of BufOnly.vim with some changes.
 - [zbirenbaum/neodim](https://github.com/zbirenbaum/neodim) - Dimming the highlights of unused functions, variables, parameters, and more.
 - [bfredl/nvim-miniyank](https://github.com/bfredl/nvim-miniyank) - The killring-alike plugin with no default mappings.
-- [chrisgrieser/nvim-genghis](https://github.com/chrisgrieser/nvim-genghis) – Convenience file operations, written in Lua.
-- [chrisgrieser/nvim-recorder](https://github.com/chrisgrieser/nvim-recorder) – Simplifying and improving how you interact with macros.
+- [chrisgrieser/nvim-genghis](https://github.com/chrisgrieser/nvim-genghis) - Convenience file operations, written in Lua.
+- [chrisgrieser/nvim-recorder](https://github.com/chrisgrieser/nvim-recorder) - Simplifying and improving how you interact with macros.
 
 
 ### Terminal Integration

--- a/README.md
+++ b/README.md
@@ -532,9 +532,9 @@ These colorschemes may not specialize in Tree-sitter directly but are written in
 - [numToStr/BufOnly.nvim](https://github.com/numToStr/BufOnly.nvim) - Lua/Neovim port of BufOnly.vim with some changes.
 - [zbirenbaum/neodim](https://github.com/zbirenbaum/neodim) - Dimming the highlights of unused functions, variables, parameters, and more.
 - [bfredl/nvim-miniyank](https://github.com/bfredl/nvim-miniyank) - The killring-alike plugin with no default mappings.
-- [chrisgrieser/nvim-genghis](https://github.com/chrisgrieser/nvim-genghis) – Convenience file operations for neovim, written in lua.
-- [chrisgrieser/nvim-recorder](https://github.com/chrisgrieser/nvim-recorder) – About
-Simplifying and improving how you interact with macros in neovim.
+- [chrisgrieser/nvim-genghis](https://github.com/chrisgrieser/nvim-genghis) – Convenience file operations, written in lua.
+- [chrisgrieser/nvim-recorder](https://github.com/chrisgrieser/nvim-recorder) – Simplifying and improving how you interact with macros.
+
 
 ### Terminal Integration
 

--- a/README.md
+++ b/README.md
@@ -532,7 +532,7 @@ These colorschemes may not specialize in Tree-sitter directly but are written in
 - [numToStr/BufOnly.nvim](https://github.com/numToStr/BufOnly.nvim) - Lua/Neovim port of BufOnly.vim with some changes.
 - [zbirenbaum/neodim](https://github.com/zbirenbaum/neodim) - Dimming the highlights of unused functions, variables, parameters, and more.
 - [bfredl/nvim-miniyank](https://github.com/bfredl/nvim-miniyank) - The killring-alike plugin with no default mappings.
-- [chrisgrieser/nvim-genghis](https://github.com/chrisgrieser/nvim-genghis) – Convenience file operations, written in lua.
+- [chrisgrieser/nvim-genghis](https://github.com/chrisgrieser/nvim-genghis) – Convenience file operations, written in Lua.
 - [chrisgrieser/nvim-recorder](https://github.com/chrisgrieser/nvim-recorder) – Simplifying and improving how you interact with macros.
 
 

--- a/README.md
+++ b/README.md
@@ -532,6 +532,9 @@ These colorschemes may not specialize in Tree-sitter directly but are written in
 - [numToStr/BufOnly.nvim](https://github.com/numToStr/BufOnly.nvim) - Lua/Neovim port of BufOnly.vim with some changes.
 - [zbirenbaum/neodim](https://github.com/zbirenbaum/neodim) - Dimming the highlights of unused functions, variables, parameters, and more.
 - [bfredl/nvim-miniyank](https://github.com/bfredl/nvim-miniyank) - The killring-alike plugin with no default mappings.
+- [chrisgrieser/nvim-genghis](https://github.com/chrisgrieser/nvim-genghis) – Convenience file operations for neovim, written in lua.
+- [chrisgrieser/nvim-recorder](https://github.com/chrisgrieser/nvim-recorder) – About
+Simplifying and improving how you interact with macros in neovim.
 
 ### Terminal Integration
 


### PR DESCRIPTION
Checklist:

- [x] The plugin is specifically built for Neovim, or if it's a colorscheme, it supports treesitter syntax.
- [x] The lines end with a `.`. This is to conform to `awesome-list` linting and requirements.
- [x] It's not already on the list.
- [x] The title of the pull request is ```Add/Update/Remove `username/repo` ``` when adding a new plugin.
- [x] The description doesn't start with `A Neovim plugin for..`, or `A plugin for..`.
- [x] The description doesn't mention that it's a Neovim plugin, it's obvious from the rest of the document.
- [x] Neovim is spelled as `Neovim` (not `nvim`, `NeoVim` or `neovim`), Vim is spelled as `Vim` (capitalized), Lua is spelled as `Lua` (capitalized).
