### PR TITLE
Add `emileferreira/nvim-strict`

### DIFF
--- a/README.md
+++ b/README.md
@@ -765,6 +765,7 @@ These colorschemes may not specialize in Tree-sitter directly but are written in
 - [mcauley-penney/tidy.nvim](https://github.com/mcauley-penney/tidy.nvim) - Clear trailing whitespace and empty lines at end of file on every save.
 - [MunifTanjim/prettier.nvim](https://github.com/MunifTanjim/prettier.nvim) - Prettier integration.
 - [echasnovski/mini.nvim#mini.align](https://github.com/echasnovski/mini.nvim/blob/main/readmes/mini-align.md) - Module of `mini.nvim` for aligning text interactively (with or without instant preview).
+- [emileferreira/nvim-strict](https://github.com/emileferreira/nvim-strict) - Strictly enforce configurable, best-practice code style by exposing deep nesting, overlong lines, trailing whitespace, trailing empty lines and inconsistent indentation.
 
 #### Indent
 


### PR DESCRIPTION
Checklist:

- [x] The plugin is specifically built for Neovim, or if it's a colorscheme, it supports treesitter syntax.
- [x] The lines end with a `.`. This is to conform to `awesome-list` linting and requirements.
- [x] It's not already on the list.
- [x] The title of the pull request is ```Add/Update/Remove `username/repo` ``` when adding a new plugin.
- [x] The description doesn't start with `A Neovim plugin for..`, or `A plugin for..`.
- [x] The description doesn't mention that it's a Neovim plugin, it's obvious from the rest of the document.
- [x] Neovim is spelled as `Neovim` (not `nvim`, `NeoVim` or `neovim`), Vim is spelled as `Vim` (capitalized), Lua is spelled as `Lua` (capitalized).
