### PR TITLE
Add `jonathandion/web-dev.nvim`

### DIFF
--- a/README.md
+++ b/README.md
@@ -858,7 +858,7 @@ These colorschemes may not specialize in Tree-sitter directly but are written in
 - [cunderw/nvim](https://github.com/cunderw/nvim) - Neovim custom configuration, focused on JS/TS, Go, and Java development. Very IDE like.
 - [otavioschwanck/mood-nvim](https://github.com/otavioschwanck/mood-nvim) - Ready to use configuration for Ruby on Rails, JavaScript and Typescript.
 - [ldelossa/nvim-ide](https://github.com/ldelossa/nvim-ide) - A full featured IDE layer heavily inspired by VSCode.
-- [jonathandion/web-dev.nvim](https://github.com/jonathandion/web-dev.nvim) - Small, Simple and Flexible Configuration for Web Development ✨.
+- [jonathandion/web-dev.nvim](https://github.com/jonathandion/web-dev.nvim) - Small, simple and flexible configuration for web development ✨.
 
 ## External
 

--- a/README.md
+++ b/README.md
@@ -858,6 +858,7 @@ These colorschemes may not specialize in Tree-sitter directly but are written in
 - [cunderw/nvim](https://github.com/cunderw/nvim) - Neovim custom configuration, focused on JS/TS, Go, and Java development. Very IDE like.
 - [otavioschwanck/mood-nvim](https://github.com/otavioschwanck/mood-nvim) - Ready to use configuration for Ruby on Rails, JavaScript and Typescript.
 - [ldelossa/nvim-ide](https://github.com/ldelossa/nvim-ide) - A full featured IDE layer heavily inspired by VSCode.
+- [jonathandion/web-dev.nvim](https://github.com/jonathandion/web-dev.nvim) - Small, Simple and Flexible Configuration for Web Development ✨.
 
 ## External
 


### PR DESCRIPTION
Added jonathandion/web-dev.nvim to Preconfigured Configuration section.

Checklist:

- [x] The plugin is specifically built for Neovim, or if it's a colorscheme, it supports treesitter syntax.
- [x] The lines end with a `.`. This is to conform to `awesome-list` linting and requirements.
- [x] It's not already on the list.
- [x] The title of the pull request is ```Add/Update/Remove `username/repo` ``` when adding a new plugin.
- [x] The description doesn't start with `A Neovim plugin for..`, or `A plugin for..`.
- [x] The description doesn't mention that it's a Neovim plugin, it's obvious from the rest of the document.
- [x] Neovim is spelled as `Neovim` (not `nvim`, `NeoVim` or `neovim`), Vim is spelled as `Vim` (capitalized), Lua is spelled as `Lua` (capitalized).
