### PR TITLE
PR template: Explicitly forbid "... for Neovim"

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,6 +4,6 @@ Checklist:
 - [ ] The lines end with a `.`. This is to conform to `awesome-list` linting and requirements.
 - [ ] It's not already on the list.
 - [ ] The title of the pull request is ```Add/Update/Remove `username/repo` ``` when adding a new plugin.
-- [ ] The description doesn't start with `A Neovim plugin for..`, or `A plugin for..`.
+- [ ] The description doesn't start with `A Neovim plugin for...` or `A plugin for...`, and doesn't end with `... for Neovim`.
 - [ ] The description doesn't mention that it's a Neovim plugin, it's obvious from the rest of the document.
 - [ ] Neovim is spelled as `Neovim` (not `nvim`, `NeoVim` or `neovim`), Vim is spelled as `Vim` (capitalized), Lua is spelled as `Lua` (capitalized).


### PR DESCRIPTION
See the discussion in #634.

The phrase "... for Neovim" is redundant in a list about Neovim plugins. There's already a line that addresses it as a concept, but this PR adds the phrase explicitly.

I've seen quite a number of recent PRs get delayed waiting for this change, so hopefully it helps
makes the submission process smoother.

Checklist:

- [X] The plugin is specifically built for Neovim, or if it's a colorscheme, it supports treesitter syntax.
- [X] The lines end with a `.`. This is to conform to `awesome-list` linting and requirements.
- [X] It's not already on the list.
- [X] The title of the pull request is ```Add/Update/Remove `username/repo` ``` when adding a new plugin.
- [X] The description doesn't start with `A Neovim plugin for..`, or `A plugin for..`.
- [X] The description doesn't mention that it's a Neovim plugin, it's obvious from the rest of the document.
- [X] Neovim is spelled as `Neovim` (not `nvim`, `NeoVim` or `neovim`), Vim is spelled as `Vim` (capitalized), Lua is spelled as `Lua` (capitalized).