### PR TITLE
Add `jinzhongjia/LspUI.nvim`

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,7 @@ You can find them listed on the [Neovim wiki](https://github.com/neovim/neovim/w
 - [ranjithshegde/ccls.nvim](https://github.com/ranjithshegde/ccls.nvim) - Use off-spec extensions of ccls LSP and browse AST.
 - [idanarye/nvim-buffls](https://github.com/idanarye/nvim-buffls) - Add LSP functionality to specific Neovim buffers.
 - [DNLHC/glance.nvim](https://github.com/DNLHC/glance.nvim) - A pretty window for previewing, navigating and editing your LSP locations.
+- [jinzhongjia/LspUI.nvim](https://github.com/jinzhongjia/LspUI.nvim) - A modern and useful UI plugin that wraps lsp operations. 
 
 ##### LSP Installer
 

--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ You can find them listed on the [Neovim wiki](https://github.com/neovim/neovim/w
 - [idanarye/nvim-buffls](https://github.com/idanarye/nvim-buffls) - Add LSP functionality to specific Neovim buffers.
 - [DNLHC/glance.nvim](https://github.com/DNLHC/glance.nvim) - A pretty window for previewing, navigating and editing your LSP locations.
 - [linrongbin16/lsp-progress.nvim](https://github.com/linrongbin16/lsp-progress.nvim) - Another simple lsp progress status for Neovim.
-- [jinzhongjia/LspUI.nvim](https://github.com/jinzhongjia/LspUI.nvim) - A modern and useful UI that wraps lsp operations. 
+- [jinzhongjia/LspUI.nvim](https://github.com/jinzhongjia/LspUI.nvim) - A modern and useful UI that wraps LSP operations. 
 
 ##### LSP Installer
 


### PR DESCRIPTION
Checklist:

- [x] The plugin is specifically built for Neovim, or if it's a colorscheme, it supports treesitter syntax.
- [x] The lines end with a `.`. This is to conform to `awesome-list` linting and requirements.
- [x] It's not already on the list.
- [x] The title of the pull request is ```Add/Update/Remove `username/repo` ``` when adding a new plugin.
- [x] The description doesn't start with `A Neovim plugin for...` or `A plugin for...`, and doesn't end with `... for Neovim`.
- [x] The description doesn't mention that it's a Neovim plugin, it's obvious from the rest of the document.
- [x] Neovim is spelled as `Neovim` (not `nvim`, `NeoVim` or `neovim`), Vim is spelled as `Vim` (capitalized), Lua is spelled as `Lua` (capitalized).
