### PR TITLE
Add `4e554c4c/darkman.nvim`

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@
   - [Color](#color)
   - [Colorscheme](#colorscheme)
     - [Colorscheme Creation](#colorscheme-creation)
+    - [Colorscheme Switchers](#colorscheme-switchers)
   - [Bars and Lines](#bars-and-lines)
     - [Statusline](#statusline)
     - [Tabline](#tabline)
@@ -420,8 +421,8 @@ These colorschemes may not specialize in Tree-sitter directly but are written in
 
 #### Colorscheme Switchers
 
-- [4e554c4c/darkman.nvim](https://github.com/4e554c4c/darkman.nvim) - A plugin to follow the system dark-mode setting on Linux.
-- [f-person/auto-dark-mode.nvim](https://github.com/f-person/auto-dark-mode.nvim) - A plugin to follow the system appearance on macOS
+- [4e554c4c/darkman.nvim](https://github.com/4e554c4c/darkman.nvim) -Follow the system dark-mode setting on Linux.
+- [f-person/auto-dark-mode.nvim](https://github.com/f-person/auto-dark-mode.nvim) - Follow the system appearance on macOS.
 
 ### Bars and Lines
 

--- a/README.md
+++ b/README.md
@@ -421,6 +421,7 @@ These colorschemes may not specialize in Tree-sitter directly but are written in
 #### Colorscheme Switchers
 
 - [4e554c4c/darkman.nvim](https://github.com/4e554c4c/darkman.nvim) - A plugin to follow the system dark-mode setting on Linux.
+- [f-person/auto-dark-mode.nvim](https://github.com/f-person/auto-dark-mode.nvim) - A plugin to follow the system appearance on macOS
 
 ### Bars and Lines
 

--- a/README.md
+++ b/README.md
@@ -418,6 +418,10 @@ These colorschemes may not specialize in Tree-sitter directly but are written in
 - [echasnovski/mini.nvim#mini.base16](https://github.com/echasnovski/mini.nvim/blob/main/readmes/mini-base16.md) - Module of `mini.nvim` with fast implementation of base16 theme for manually supplied palette.
 - [ThemerCorp/themer.lua](https://github.com/themercorp/themer.lua) - A simple highlighter plugin for neovim. It has a huge collection of colorschemes. It also has ability to create colorschemes for Vim/Neovim and other supported apps (such as kitty and alacritty).
 
+#### Colorscheme Switchers
+
+- [4e554c4c/darkman.nvim](https://github.com/4e554c4c/darkman.nvim) - A plugin to follow the system dark-mode setting on Linux.
+
 ### Bars and Lines
 
 - [SmiteshP/nvim-navic](https://github.com/SmiteshP/nvim-navic) - A simple statusline/winbar component that uses LSP to show your current code context.

--- a/README.md
+++ b/README.md
@@ -421,7 +421,7 @@ These colorschemes may not specialize in Tree-sitter directly but are written in
 
 #### Colorscheme Switchers
 
-- [4e554c4c/darkman.nvim](https://github.com/4e554c4c/darkman.nvim) -Follow the system dark-mode setting on Linux.
+- [4e554c4c/darkman.nvim](https://github.com/4e554c4c/darkman.nvim) - Follow the system dark-mode setting on Linux.
 - [f-person/auto-dark-mode.nvim](https://github.com/f-person/auto-dark-mode.nvim) - Follow the system appearance on macOS.
 
 ### Bars and Lines


### PR DESCRIPTION
Checklist:

- [x] The plugin is specifically built for Neovim, or if it's a colorscheme, it supports treesitter syntax.
- [x] The lines end with a `.`. This is to conform to `awesome-list` linting and requirements.
- [x] It's not already on the list.
- [x] The title of the pull request is ```Add/Update/Remove `username/repo` ``` when adding a new plugin.
- [x] The description doesn't start with `A Neovim plugin for...` or `A plugin for...`, and doesn't end with `... for Neovim`.
- [x] The description doesn't mention that it's a Neovim plugin, it's obvious from the rest of the document.
- [x] Neovim is spelled as `Neovim` (not `nvim`, `NeoVim` or `neovim`), Vim is spelled as `Vim` (capitalized), Lua is spelled as `Lua` (capitalized).
