### PR TITLE
Add `tokiory/neovim-boilerplate` & `frans-johansson/lazy-nvim-starter`

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ Neovim supports a wide variety of UI's.
 You can find them listed on the [Neovim wiki](https://github.com/neovim/neovim/wiki/Related-projects#gui)
 
 ## Starter templates
-- [tokiory/neovim-boilerplate](https://github.com/tokiory/neovim-boilerplate) - Starter boilerplate for making new configuration
+- [tokiory/neovim-boilerplate](https://github.com/tokiory/neovim-boilerplate) - Starter boilerplate for making new configurations.
 
 ## Plugin
 

--- a/README.md
+++ b/README.md
@@ -90,8 +90,9 @@ Have a problem a plugin can solve? Add it to the [nvim-lua wishlist](https://git
 Neovim supports a wide variety of UI's.
 You can find them listed on the [Neovim wiki](https://github.com/neovim/neovim/wiki/Related-projects#gui)
 
-## Starter templates
+## Starter Templates
 - [tokiory/neovim-boilerplate](https://github.com/tokiory/neovim-boilerplate) - Starter boilerplate for making new configurations.
+- [frans-johansson/lazy-nvim-starter](https://github.com/frans-johansson/lazy-nvim-starter) - Starter boilerplate with lazy plugin manager.
 
 ## Plugin
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@
 
 - [Wishlist](#wishlist)
 - [UI](#ui)
+- [Starter Templates](#starter-templates)
 - [Plugin](#plugin)
   - [Plugin Manager](#plugin-manager)
   - [LSP](#lsp)
@@ -88,6 +89,9 @@ Have a problem a plugin can solve? Add it to the [nvim-lua wishlist](https://git
 
 Neovim supports a wide variety of UI's.
 You can find them listed on the [Neovim wiki](https://github.com/neovim/neovim/wiki/Related-projects#gui)
+
+## Starter templates
+- [tokiory/neovim-boilerplate](https://github.com/tokiory/neovim-boilerplate) - Starter boilerplate for making new configuration
 
 ## Plugin
 


### PR DESCRIPTION
### Repo URL:

- https://github.com/tokiory/neovim-boilerplate
- https://github.com/frans-johansson/lazy-nvim-starter

### Checklist:

- [x] The plugin is specifically built for Neovim, or if it's a colorscheme, it supports treesitter syntax.
- [x] The lines end with a `.`. This is to conform to `awesome-list` linting and requirements.
- [x] The title of the pull request is ```Add/Update/Remove `username/repo` ``` (notice the backticks around ``` `username/repo` ```) when adding a new plugin.
- [x] The description doesn't mention that it's a Neovim plugin, it's obvious from the rest of the document. No mentions of the word `plugin` unless it's related to something else.
- [x] The description doesn't contain emojis.
- [x] Neovim is spelled as `Neovim` (not `nvim`, `NeoVim` or `neovim`), Vim is spelled as `Vim` (capitalized), Lua is spelled as `Lua` (capitalized), Tree-sitter is spelled as `Tree-sitter`.
- [x] Acronyms should be fully capitalized, for example `LSP`, `TS`, `YAML`, etc.
