### PR TITLE
Add `m4xshen/hardtime.nvim`

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@
     - [Tmux](#tmux)
   - [Game](#game)
     - [Competitive Programming](#competitive-programming)
+  - [Workflow](#workflow)
   - [Preconfigured Configuration](#preconfigured-configuration)
 - [External](#external)
   - [Version Manager](#version-manager)
@@ -920,6 +921,10 @@ These colorschemes may not specialize in Tree-sitter directly but are written in
 
 - [p00f/cphelper.nvim](https://github.com/p00f/cphelper.nvim) - Neovim helper for competitive programming written in Lua.
 - [xeluxee/competitest.nvim](https://github.com/xeluxee/competitest.nvim) - A plugin to automate testcases management and checking for Competitive Programming contests.
+
+### Workflow
+
+- [m4xshen/hardtime.nvim](https://github.com/m4xshen/hardtime.nvim) - Helping you establish good command workflow and habit.
 
 ### Preconfigured Configuration
 

--- a/README.md
+++ b/README.md
@@ -925,6 +925,7 @@ These colorschemes may not specialize in Tree-sitter directly but are written in
 ### Workflow
 
 - [m4xshen/hardtime.nvim](https://github.com/m4xshen/hardtime.nvim) - Helping you establish good command workflow and habit.
+- [antonk52/bad-practices.nvim](https://github.com/antonk52/bad-practices.nvim) - A plugin to help give up bad practices in Vim.
 
 ### Preconfigured Configuration
 

--- a/README.md
+++ b/README.md
@@ -925,7 +925,7 @@ These colorschemes may not specialize in Tree-sitter directly but are written in
 ### Workflow
 
 - [m4xshen/hardtime.nvim](https://github.com/m4xshen/hardtime.nvim) - Helping you establish good command workflow and habit.
-- [antonk52/bad-practices.nvim](https://github.com/antonk52/bad-practices.nvim) - A plugin to help give up bad practices in Vim.
+- [antonk52/bad-practices.nvim](https://github.com/antonk52/bad-practices.nvim) - Helping you give up bad practices in Vim.
 
 ### Preconfigured Configuration
 


### PR DESCRIPTION
### Repo URL:

https://github.com/m4xshen/hardtime.nvim

### Checklist:

- [x] The plugin is specifically built for Neovim, or if it's a colorscheme, it supports treesitter syntax.
- [x] The lines end with a `.`. This is to conform to `awesome-list` linting and requirements.
- [x] The title of the pull request is ```Add/Update/Remove `username/repo` ``` (notice the backticks around ``` `username/repo` ```) when adding a new plugin.
- [x] The description doesn't mention that it's a Neovim plugin, it's obvious from the rest of the document. No mentions of the word `plugin` unless it's related to something else.
- [x] The description doesn't contain emojis.
- [x] Neovim is spelled as `Neovim` (not `nvim`, `NeoVim` or `neovim`), Vim is spelled as `Vim` (capitalized), Lua is spelled as `Lua` (capitalized), Tree-sitter is spelled as `Tree-sitter`.
- [x] Acronyms should be fully capitalized, for example `LSP`, `TS`, `YAML`, etc.
