### PR TITLE
Add `dmmulroy/tsc.nvim`

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@
   - [Completion](#completion)
   - [Programming Languages Support](#programming-languages-support)
     - [Golang](#golang)
+    - [TypeScript](#typescript)
     - [YAML](#yaml)
     - [Web Development](#web-development)
     - [Markdown and LaTeX](#markdown-and-latex)
@@ -192,6 +193,9 @@ You can find them listed on the [Neovim wiki](https://github.com/neovim/neovim/w
 - [olexsmir/gopher.nvim](https://github.com/olexsmir/gopher.nvim/) - Plugin for making Golang development easiest.
 - [rafaelsq/nvim-goc.lua](https://github.com/rafaelsq/nvim-goc.lua) - Highlight your buffer with Golang Code Coverage.
 - [crusj/hierarchy-tree-go.nvim](https://github.com/crusj/hierarchy-tree-go.nvim) - Neovim plugin for Golang, callHierarchy UI tree.
+
+#### TypeScript
+- [dmmulroy/tsc.nvim](https://github.com/dmmulroy/tsc.nvim) - Asynchronous project-wide TypeScript type-checking using the TypeScript compiler (tsc) with results loaded into a quickfix list.
 
 #### YAML
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,6 @@
   - [Completion](#completion)
   - [Programming Languages Support](#programming-languages-support)
     - [Golang](#golang)
-    - [TypeScript](#typescript)
     - [YAML](#yaml)
     - [Web Development](#web-development)
     - [Markdown and LaTeX](#markdown-and-latex)
@@ -183,6 +182,7 @@ You can find them listed on the [Neovim wiki](https://github.com/neovim/neovim/w
 - [AckslD/swenv.nvim](https://github.com/AckslD/swenv.nvim) - Tiny plugin to quickly switch Python virtual environments without restarting.
 - [gennaro-tedesco/nvim-jqx](https://github.com/gennaro-tedesco/nvim-jqx) - Interactive interface for JSON files.
 - [nanotee/sqls.nvim](https://github.com/nanotee/sqls.nvim) - SQL database connection plugin + LSP client.
+- [dmmulroy/tsc.nvim](https://github.com/dmmulroy/tsc.nvim) - Asynchronous project-wide TypeScript type-checking using the TypeScript compiler (TSC) with results loaded into a quickfix list.
 
 #### Golang
 
@@ -193,9 +193,6 @@ You can find them listed on the [Neovim wiki](https://github.com/neovim/neovim/w
 - [olexsmir/gopher.nvim](https://github.com/olexsmir/gopher.nvim/) - Plugin for making Golang development easiest.
 - [rafaelsq/nvim-goc.lua](https://github.com/rafaelsq/nvim-goc.lua) - Highlight your buffer with Golang Code Coverage.
 - [crusj/hierarchy-tree-go.nvim](https://github.com/crusj/hierarchy-tree-go.nvim) - Neovim plugin for Golang, callHierarchy UI tree.
-
-#### TypeScript
-- [dmmulroy/tsc.nvim](https://github.com/dmmulroy/tsc.nvim) - Asynchronous project-wide TypeScript type-checking using the TypeScript compiler (TSC) with results loaded into a quickfix list.
 
 #### YAML
 

--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ You can find them listed on the [Neovim wiki](https://github.com/neovim/neovim/w
 - [crusj/hierarchy-tree-go.nvim](https://github.com/crusj/hierarchy-tree-go.nvim) - Neovim plugin for Golang, callHierarchy UI tree.
 
 #### TypeScript
-- [dmmulroy/tsc.nvim](https://github.com/dmmulroy/tsc.nvim) - Asynchronous project-wide TypeScript type-checking using the TypeScript compiler (tsc) with results loaded into a quickfix list.
+- [dmmulroy/tsc.nvim](https://github.com/dmmulroy/tsc.nvim) - Asynchronous project-wide TypeScript type-checking using the TypeScript compiler (TSC) with results loaded into a quickfix list.
 
 #### YAML
 


### PR DESCRIPTION
### Repo URL:

https://github.com/dmmulroy/tsc.nvim

### Checklist:

- [x] The plugin is specifically built for Neovim, or if it's a colorscheme, it supports treesitter syntax.
- [x] The lines end with a `.`. This is to conform to `awesome-list` linting and requirements.
- [x] The title of the pull request is ```Add/Update/Remove `username/repo` ``` (notice the backticks around ``` `username/repo` ```) when adding a new plugin.
- [x] The description doesn't mention that it's a Neovim plugin, it's obvious from the rest of the document. No mentions of the word `plugin` unless it's related to something else.
- [x] The description doesn't contain emojis.
- [x] Neovim is spelled as `Neovim` (not `nvim`, `NeoVim` or `neovim`), Vim is spelled as `Vim` (capitalized), Lua is spelled as `Lua` (capitalized), Tree-sitter is spelled as `Tree-sitter`.
- [x] Acronyms should be fully capitalized, for example `LSP`, `TS`, `YAML`, etc.
