### PR TITLE
Replace `mrjones2014/nvim-ts-rainbow` with `HiPhish/rainbow-delimiters.nvim`

### DIFF
--- a/README.md
+++ b/README.md
@@ -809,7 +809,7 @@ These colorschemes may not specialize in Tree-sitter directly but are written in
 - [altermo/ultimate-autopair.nvim](https://github.com/altermo/ultimate-autopair.nvim) - Autopair with extensions.
 - [utilyre/sentiment.nvim](https://github.com/utilyre/sentiment.nvim) - Enhanced matchparen.
 - [monaqa/dial.nvim](https://github.com/monaqa/dial.nvim) - Extended increment/decrement.
-- [HiPhish/rainbow-delimiters.nvim](https://github.com/HiPhish/rainbow-delimiters.nvim) - Rainbow delimiters for Neovim with Tree-sitter.
+- [HiPhish/rainbow-delimiters.nvim](https://github.com/HiPhish/rainbow-delimiters.nvim) - Rainbow delimiters with Tree-sitter.
 - [AckslD/nvim-revJ.lua](https://github.com/AckslD/nvim-revJ.lua) - Neovim Lua plugin for doing the opposite of join-line (J) for arguments.
 - [Pocco81/TrueZen.nvim](https://github.com/Pocco81/TrueZen.nvim) - Clean and elegant distraction-free writing.
 - [Pocco81/HighStr.nvim](https://github.com/Pocco81/HighStr.nvim) - Highlight visual selections like in a normal document editor!

--- a/README.md
+++ b/README.md
@@ -809,7 +809,7 @@ These colorschemes may not specialize in Tree-sitter directly but are written in
 - [altermo/ultimate-autopair.nvim](https://github.com/altermo/ultimate-autopair.nvim) - Autopair with extensions.
 - [utilyre/sentiment.nvim](https://github.com/utilyre/sentiment.nvim) - Enhanced matchparen.
 - [monaqa/dial.nvim](https://github.com/monaqa/dial.nvim) - Extended increment/decrement.
-- [mrjones2014/nvim-ts-rainbow](https://github.com/mrjones2014/nvim-ts-rainbow) - Rainbow :rainbow: delimiters using tree-sitter :rainbow:.
+- [HiPhish/rainbow-delimiters.nvim](https://github.com/HiPhish/rainbow-delimiters.nvim) - Rainbow delimiters for Neovim with Tree-sitter.
 - [AckslD/nvim-revJ.lua](https://github.com/AckslD/nvim-revJ.lua) - Neovim Lua plugin for doing the opposite of join-line (J) for arguments.
 - [Pocco81/TrueZen.nvim](https://github.com/Pocco81/TrueZen.nvim) - Clean and elegant distraction-free writing.
 - [Pocco81/HighStr.nvim](https://github.com/Pocco81/HighStr.nvim) - Highlight visual selections like in a normal document editor!


### PR DESCRIPTION
The original one is deprecated, use the new one instead.

### Repo URL:

https://github.com/HiPhish/rainbow-delimiters.nvim

### Checklist:

- [x] The plugin is specifically built for Neovim, or if it's a colorscheme, it supports treesitter syntax.
- [x] The lines end with a `.`. This is to conform to `awesome-list` linting and requirements.
- [x] The title of the pull request is ```Add/Update/Remove `username/repo` ``` (notice the backticks around ``` `username/repo` ```) when adding a new plugin.
- [x] The description doesn't mention that it's a Neovim plugin, it's obvious from the rest of the document. No mentions of the word `plugin` unless it's related to something else.
- [x] The description doesn't contain emojis.
- [x] Neovim is spelled as `Neovim` (not `nvim`, `NeoVim` or `neovim`), Vim is spelled as `Vim` (capitalized), Lua is spelled as `Lua` (capitalized), Tree-sitter is spelled as `Tree-sitter`.
- [x] Acronyms should be fully capitalized, for example `LSP`, `TS`, `YAML`, etc.
