### PR TITLE
Add `Robitx/gp.nvim`, `dpayne/CodeGPT.nvim` and `jackMort/ChatGPT.nvim`

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@
   - [Plugin Manager](#plugin-manager)
   - [LSP](#lsp)
   - [Completion](#completion)
+  - [AI (ChatGPT/GPT/LLM) integration](#ai-chatgptgptllm-integration)
   - [Programming Languages Support](#programming-languages-support)
     - [Golang](#golang)
     - [YAML](#yaml)
@@ -175,6 +176,12 @@ You can find them listed on the [Neovim wiki](https://github.com/neovim/neovim/w
 - [vigoux/complementree.nvim](https://github.com/vigoux/complementree.nvim) - Light and synchronous completion plugin based on tree-sitter and with a functional-programming interface.
 - [simrat39/rust-tools.nvim](https://github.com/simrat39/rust-tools.nvim) - Tools for better development in Rust using Neovim's builtin LSP.
 - [zbirenbaum/copilot.lua](https://github.com/zbirenbaum/copilot.lua) - Fully featured Lua replacement for [GitHub/copilot.vim](https://github.com/github/copilot.vim).
+
+### AI (ChatGPT/GPT/LLM) integration
+
+- [Robitx/gp.nvim](https://github.com/Robitx/gp.nvim) - ChatGPT like sessions and instructable text/code operations in your favorite editor.
+- [dpayne/CodeGPT.nvim](https://github.com/dpayne/CodeGPT.nvim) - Provides commands to interact with ChatGPT, the focus is around code related usages.
+- [jackMort/ChatGPT.nvim](https://github.com/jackMort/ChatGPT.nvim) - Effortless Natural Language Generation with OpenAI's ChatGPT API.
 
 ### Programming Languages Support
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
   - [Plugin Manager](#plugin-manager)
   - [LSP](#lsp)
   - [Completion](#completion)
-  - [AI (ChatGPT/GPT/LLM) integration](#ai-chatgptgptllm-integration)
+  - [AI](#ai)
   - [Programming Languages Support](#programming-languages-support)
     - [Golang](#golang)
     - [YAML](#yaml)
@@ -177,7 +177,7 @@ You can find them listed on the [Neovim wiki](https://github.com/neovim/neovim/w
 - [simrat39/rust-tools.nvim](https://github.com/simrat39/rust-tools.nvim) - Tools for better development in Rust using Neovim's builtin LSP.
 - [zbirenbaum/copilot.lua](https://github.com/zbirenbaum/copilot.lua) - Fully featured Lua replacement for [GitHub/copilot.vim](https://github.com/github/copilot.vim).
 
-### AI (ChatGPT/GPT/LLM) integration
+### AI
 
 - [Robitx/gp.nvim](https://github.com/Robitx/gp.nvim) - ChatGPT like sessions and instructable text/code operations in your favorite editor.
 - [dpayne/CodeGPT.nvim](https://github.com/dpayne/CodeGPT.nvim) - Provides commands to interact with ChatGPT, the focus is around code related usages.


### PR DESCRIPTION
- Adds an additional section for AI plugins integrating large language models such as GPT
- Adds gp.nvim, CodeGPT.nvim and ChatGPT.nvim plugins

### Repo URL:

- https://github.com/Robitx/gp.nvim
- https://github.com/dpayne/CodeGPT.nvim
- https://github.com/jackMort/ChatGPT.nvim

### Checklist:

- [x] The plugin is specifically built for Neovim, or if it's a colorscheme, it supports treesitter syntax.
- [x] The lines end with a `.`. This is to conform to `awesome-list` linting and requirements.
- [x] The title of the pull request is ```Add/Update/Remove `username/repo` ``` (notice the backticks around ``` `username/repo` ```) when adding a new plugin.
- [x] The description doesn't mention that it's a Neovim plugin, it's obvious from the rest of the document. No mentions of the word `plugin` unless it's related to something else.
- [x] The description doesn't contain emojis.
- [x] Neovim is spelled as `Neovim` (not `nvim`, `NeoVim` or `neovim`), Vim is spelled as `Vim` (capitalized), Lua is spelled as `Lua` (capitalized), Tree-sitter is spelled as `Tree-sitter`.
- [x] Acronyms should be fully capitalized, for example `LSP`, `TS`, `YAML`, etc.
