### PR TITLE
Add `NormalNvim/NormalNvim`, `Zeioth/Compiler.nvim`, `Zeioth/Markmap.nvim`

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,7 +231,7 @@ You can find them listed on the [Neovim wiki](https://github.com/neovim/neovim/w
 - [yaocccc/nvim-hl-mdcodeblock.lua](https://github.com/yaocccc/nvim-hl-mdcodeblock.lua) - Highlight markdown codeblock using Tree-sitter.
 - [kiran94/edit-markdown-table.nvim](https://github.com/kiran94/edit-markdown-table.nvim) - Edit Markdown Tables using Tree-sitter.
 - [richardbizik/nvim-toc](https://github.com/richardbizik/nvim-toc) - Easily generate table of contents for markdown files.
-- [Zeioth/markmap.nvim](https://github.com/Zeioth/markmap.nvim) -  Visualize your Markdown as mindmaps with markmap.
+- [Zeioth/markmap.nvim](https://github.com/Zeioth/markmap.nvim) -  Visualize your Markdown as mindmaps.
 
 ### Language
 

--- a/README.md
+++ b/README.md
@@ -231,6 +231,7 @@ You can find them listed on the [Neovim wiki](https://github.com/neovim/neovim/w
 - [yaocccc/nvim-hl-mdcodeblock.lua](https://github.com/yaocccc/nvim-hl-mdcodeblock.lua) - Highlight markdown codeblock using Tree-sitter.
 - [kiran94/edit-markdown-table.nvim](https://github.com/kiran94/edit-markdown-table.nvim) - Edit Markdown Tables using Tree-sitter.
 - [richardbizik/nvim-toc](https://github.com/richardbizik/nvim-toc) - Easily generate table of contents for markdown files.
+- [Zeioth/markmap.nvim](https://github.com/Zeioth/markmap.nvim) -  Visualize your Markdown as mindmaps with markmap.
 
 ### Language
 
@@ -671,6 +672,7 @@ These colorschemes may not specialize in Tree-sitter directly but are written in
 
 ### Code Runner
 
+
 - [michaelb/sniprun](https://github.com/michaelb/sniprun) - Run parts of code of any language directly from Neovim.
 - [pianocomposer321/yabs.nvim](https://github.com/pianocomposer321/yabs.nvim) - Yet Another Build System, written in Lua.
 - [CRAG666/code_runner.nvim](https://github.com/CRAG666/code_runner.nvim) - The best code runner you could have, with super powers.
@@ -687,6 +689,7 @@ These colorschemes may not specialize in Tree-sitter directly but are written in
 - [idanarye/nvim-moonicipal](https://github.com/idanarye/nvim-moonicipal) - Task runner with focus on rapidly changing personal tasks.
 - [MarcHamamji/runner.nvim](https://github.com/MarcHamamji/runner.nvim) - A customizable Lua code runner.
 - [google/executor.nvim](https://github.com/google/executor.nvim) - Allows you to run command line tasks in the background and be notified of results.
+- [Zeioth/compiler.nvim](https://github.com/Zeioth/compiler.nvim) - Neovim compiler for building and running your code without having to configure anything.
 
 ### Neovim Lua Development
 
@@ -1007,6 +1010,7 @@ These colorschemes may not specialize in Tree-sitter directly but are written in
 - [jonathandion/web-dev.nvim](https://github.com/jonathandion/web-dev.nvim) - Small, simple and flexible configuration for web development ✨.
 - [linrongbin16/lin.nvim](https://github.com/linrongbin16/lin.nvim) - A highly configured Neovim distribution integrated with tons of utilities for development, inspired by spf13-vim.
 - [doctorfree/nvim-lazyman](https://github.com/doctorfree/nvim-lazyman) - Neovim configuration manager and modular configuration, supports over 40 preconfigured configurations.
+- [NormalNvim/NormalNvim](https://github.com/NormalNvim/NormalNvim) - Focused on stability for your daily work. From the creator on [Compiler.nvim](https://github.com/Zeioth/compiler.nvim).
 
 ## External
 

--- a/README.md
+++ b/README.md
@@ -1010,7 +1010,7 @@ These colorschemes may not specialize in Tree-sitter directly but are written in
 - [jonathandion/web-dev.nvim](https://github.com/jonathandion/web-dev.nvim) - Small, simple and flexible configuration for web development ✨.
 - [linrongbin16/lin.nvim](https://github.com/linrongbin16/lin.nvim) - A highly configured Neovim distribution integrated with tons of utilities for development, inspired by spf13-vim.
 - [doctorfree/nvim-lazyman](https://github.com/doctorfree/nvim-lazyman) - Neovim configuration manager and modular configuration, supports over 40 preconfigured configurations.
-- [NormalNvim/NormalNvim](https://github.com/NormalNvim/NormalNvim) - Focused on stability for your daily work. From the creator on [Compiler.nvim](https://github.com/Zeioth/compiler.nvim).
+- [NormalNvim/NormalNvim](https://github.com/NormalNvim/NormalNvim) - Focused on stability for your daily work. From the creator of Compiler.nvim.
 
 ## External
 

--- a/README.md
+++ b/README.md
@@ -231,7 +231,7 @@ You can find them listed on the [Neovim wiki](https://github.com/neovim/neovim/w
 - [yaocccc/nvim-hl-mdcodeblock.lua](https://github.com/yaocccc/nvim-hl-mdcodeblock.lua) - Highlight markdown codeblock using Tree-sitter.
 - [kiran94/edit-markdown-table.nvim](https://github.com/kiran94/edit-markdown-table.nvim) - Edit Markdown Tables using Tree-sitter.
 - [richardbizik/nvim-toc](https://github.com/richardbizik/nvim-toc) - Easily generate table of contents for markdown files.
-- [Zeioth/markmap.nvim](https://github.com/Zeioth/markmap.nvim) -  Visualize your Markdown as mindmaps.
+- [Zeioth/markmap.nvim](https://github.com/Zeioth/markmap.nvim) - Visualize your Markdown as mindmaps.
 
 ### Language
 

--- a/README.md
+++ b/README.md
@@ -689,7 +689,7 @@ These colorschemes may not specialize in Tree-sitter directly but are written in
 - [idanarye/nvim-moonicipal](https://github.com/idanarye/nvim-moonicipal) - Task runner with focus on rapidly changing personal tasks.
 - [MarcHamamji/runner.nvim](https://github.com/MarcHamamji/runner.nvim) - A customizable Lua code runner.
 - [google/executor.nvim](https://github.com/google/executor.nvim) - Allows you to run command line tasks in the background and be notified of results.
-- [Zeioth/compiler.nvim](https://github.com/Zeioth/compiler.nvim) - Neovim compiler for building and running your code without having to configure anything.
+- [Zeioth/compiler.nvim](https://github.com/Zeioth/compiler.nvim) - Compiler for building and running your code without having to configure anything.
 
 ### Neovim Lua Development
 


### PR DESCRIPTION
### Repo URL:

https://github.com/NormalNvim/NormalNvim
https://github.com/Zeioth/compiler.nvim
https://github.com/Zeioth/markmap.nvim

### Checklist:

- [ x] The plugin is specifically built for Neovim, or if it's a colorscheme, it supports treesitter syntax.
- [ x] The lines end with a `.`. This is to conform to `awesome-list` linting and requirements.
- [ x] The title of the pull request is ```Add/Update/Remove `username/repo` ``` (notice the backticks around ``` `username/repo` ```) when adding a new plugin.
- [x ] The description doesn't mention that it's a Neovim plugin, it's obvious from the rest of the document. No mentions of the word `plugin` unless it's related to something else.
- [ x] The description doesn't contain emojis.
- [x ] Neovim is spelled as `Neovim` (not `nvim`, `NeoVim` or `neovim`), Vim is spelled as `Vim` (capitalized), Lua is spelled as `Lua` (capitalized), Tree-sitter is spelled as `Tree-sitter`.
- [x ] Acronyms should be fully capitalized, for example `LSP`, `TS`, `YAML`, etc.
