### PR TITLE
Add `echasnovski/mini.nvim#mini.clue`

### DIFF
--- a/README.md
+++ b/README.md
@@ -783,6 +783,7 @@ These colorschemes may not specialize in Tree-sitter directly but are written in
 ### Keybinding
 
 - [folke/which-key.nvim](https://github.com/folke/which-key.nvim) - Neovim plugin that shows a popup with possible keybindings of the command you started typing.
+- [echasnovski/mini.nvim#mini.clue](https://github.com/echasnovski/mini.nvim/blob/main/readmes/mini-clue.md) - Module of `mini.nvim` to show next key clues. Has opt-in triggers, shows next key information after customizable delay, allows hydra-like submodes, and more.
 - [mrjones2014/legendary.nvim](https://github.com/mrjones2014/legendary.nvim) - Define your keymaps, commands, and autocommands as simple Lua tables, and create a legend for them at the same time (like VS Code's Command Palette), integrates with `which-key.nvim`.
 - [Iron-E/nvim-cartographer](https://github.com/Iron-E/nvim-cartographer) - a more convenient `:map`ping syntax for Lua environments.
 - [b0o/mapx.nvim](https://github.com/b0o/mapx.nvim) - A simpler key mapping API that mimics Neovim's `:map`-family of commands. Integrates with which-key.nvim.


### PR DESCRIPTION
### Repo URL:

https://github.com/echasnovski/mini.nvim/blob/main/readmes/mini-clue.md

### Checklist:

- [x] The plugin is specifically built for Neovim, or if it's a colorscheme, it supports treesitter syntax.
- [x] The lines end with a `.`. This is to conform to `awesome-list` linting and requirements.
- [x] The title of the pull request is ```Add/Update/Remove `username/repo` ``` (notice the backticks around ``` `username/repo` ```) when adding a new plugin.
- [x] The description doesn't mention that it's a Neovim plugin, it's obvious from the rest of the document. No mentions of the word `plugin` unless it's related to something else.
- [x] The description doesn't contain emojis.
- [x] Neovim is spelled as `Neovim` (not `nvim`, `NeoVim` or `neovim`), Vim is spelled as `Vim` (capitalized), Lua is spelled as `Lua` (capitalized), Tree-sitter is spelled as `Tree-sitter`.
- [x] Acronyms should be fully capitalized, for example `LSP`, `TS`, `YAML`, etc.
