### PR TITLE
Add `linrongbin16/fzfx.nvim`

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,7 +292,7 @@ You can find them listed on the [Neovim wiki](https://github.com/neovim/neovim/w
 - [jvgrootveld/telescope-zoxide](https://github.com/jvgrootveld/telescope-zoxide) - Telescope integration for [zoxide](https://github.com/ajeetdsouza/zoxide), a smart directory picker that tracks your usage.
 - [echasnovski/mini.nvim#mini.fuzzy](https://github.com/echasnovski/mini.nvim/blob/main/readmes/mini-fuzzy.md) - Module of `mini.nvim` with functions to perform fuzzy matching of one string to others along with fast Telescope sorter.
 - [axkirillov/easypick.nvim](https://github.com/axkirillov/easypick.nvim) - Easypick lets you easily create Telescope pickers from arbitrary console commands.
-- [linrongbin16/fzfx.vim](https://github.com/linrongbin16/fzfx.vim) - E(x)tend fzf commands missing in fzf.vim,  focused on better usability and tiny improvements.
+- [linrongbin16/fzfx.vim](https://github.com/linrongbin16/fzfx.vim) - E(x)tended fzf commands missing in fzf.vim,  focused on better usability and tiny improvements.
 
 ### File Explorer
 

--- a/README.md
+++ b/README.md
@@ -292,7 +292,7 @@ You can find them listed on the [Neovim wiki](https://github.com/neovim/neovim/w
 - [jvgrootveld/telescope-zoxide](https://github.com/jvgrootveld/telescope-zoxide) - Telescope integration for [zoxide](https://github.com/ajeetdsouza/zoxide), a smart directory picker that tracks your usage.
 - [echasnovski/mini.nvim#mini.fuzzy](https://github.com/echasnovski/mini.nvim/blob/main/readmes/mini-fuzzy.md) - Module of `mini.nvim` with functions to perform fuzzy matching of one string to others along with fast Telescope sorter.
 - [axkirillov/easypick.nvim](https://github.com/axkirillov/easypick.nvim) - Easypick lets you easily create Telescope pickers from arbitrary console commands.
-- [linrongbin16/fzfx.vim](https://github.com/linrongbin16/fzfx.vim) - E(x)tend fzf commands missing in fzf.vim, yet another fzf plugin focused on better usability and tiny improvements.
+- [linrongbin16/fzfx.vim](https://github.com/linrongbin16/fzfx.vim) - E(x)tend fzf commands missing in fzf.vim, yet another fzf-based finder focused on better usability and tiny improvements.
 
 ### File Explorer
 

--- a/README.md
+++ b/README.md
@@ -292,7 +292,7 @@ You can find them listed on the [Neovim wiki](https://github.com/neovim/neovim/w
 - [jvgrootveld/telescope-zoxide](https://github.com/jvgrootveld/telescope-zoxide) - Telescope integration for [zoxide](https://github.com/ajeetdsouza/zoxide), a smart directory picker that tracks your usage.
 - [echasnovski/mini.nvim#mini.fuzzy](https://github.com/echasnovski/mini.nvim/blob/main/readmes/mini-fuzzy.md) - Module of `mini.nvim` with functions to perform fuzzy matching of one string to others along with fast Telescope sorter.
 - [axkirillov/easypick.nvim](https://github.com/axkirillov/easypick.nvim) - Easypick lets you easily create Telescope pickers from arbitrary console commands.
-- [linrongbin16/fzfx.vim](https://github.com/linrongbin16/fzfx.vim) - E(x)tended fzf commands missing in fzf.vim,  focused on better usability and tiny improvements.
+- [linrongbin16/fzfx.nvim](https://github.com/linrongbin16/fzfx.nvim) - E(x)tended commands missing in fzf.vim, a brand new plugin build from scratch, focused on usability, customization and performance.
 
 ### File Explorer
 

--- a/README.md
+++ b/README.md
@@ -292,6 +292,7 @@ You can find them listed on the [Neovim wiki](https://github.com/neovim/neovim/w
 - [jvgrootveld/telescope-zoxide](https://github.com/jvgrootveld/telescope-zoxide) - Telescope integration for [zoxide](https://github.com/ajeetdsouza/zoxide), a smart directory picker that tracks your usage.
 - [echasnovski/mini.nvim#mini.fuzzy](https://github.com/echasnovski/mini.nvim/blob/main/readmes/mini-fuzzy.md) - Module of `mini.nvim` with functions to perform fuzzy matching of one string to others along with fast Telescope sorter.
 - [axkirillov/easypick.nvim](https://github.com/axkirillov/easypick.nvim) - Easypick lets you easily create Telescope pickers from arbitrary console commands.
+- [linrongbin16/fzfx.vim](https://github.com/linrongbin16/fzfx.vim) - E(x)tend fzf commands missing in fzf.vim, yet another fzf-based plugin focused on better usability and tiny improvements.
 
 ### File Explorer
 

--- a/README.md
+++ b/README.md
@@ -292,7 +292,7 @@ You can find them listed on the [Neovim wiki](https://github.com/neovim/neovim/w
 - [jvgrootveld/telescope-zoxide](https://github.com/jvgrootveld/telescope-zoxide) - Telescope integration for [zoxide](https://github.com/ajeetdsouza/zoxide), a smart directory picker that tracks your usage.
 - [echasnovski/mini.nvim#mini.fuzzy](https://github.com/echasnovski/mini.nvim/blob/main/readmes/mini-fuzzy.md) - Module of `mini.nvim` with functions to perform fuzzy matching of one string to others along with fast Telescope sorter.
 - [axkirillov/easypick.nvim](https://github.com/axkirillov/easypick.nvim) - Easypick lets you easily create Telescope pickers from arbitrary console commands.
-- [linrongbin16/fzfx.vim](https://github.com/linrongbin16/fzfx.vim) - E(x)tend fzf commands missing in fzf.vim, yet another fzf-based plugin focused on better usability and tiny improvements.
+- [linrongbin16/fzfx.vim](https://github.com/linrongbin16/fzfx.vim) - E(x)tend fzf commands missing in fzf.vim, yet another fzf plugin focused on better usability and tiny improvements.
 
 ### File Explorer
 

--- a/README.md
+++ b/README.md
@@ -292,7 +292,7 @@ You can find them listed on the [Neovim wiki](https://github.com/neovim/neovim/w
 - [jvgrootveld/telescope-zoxide](https://github.com/jvgrootveld/telescope-zoxide) - Telescope integration for [zoxide](https://github.com/ajeetdsouza/zoxide), a smart directory picker that tracks your usage.
 - [echasnovski/mini.nvim#mini.fuzzy](https://github.com/echasnovski/mini.nvim/blob/main/readmes/mini-fuzzy.md) - Module of `mini.nvim` with functions to perform fuzzy matching of one string to others along with fast Telescope sorter.
 - [axkirillov/easypick.nvim](https://github.com/axkirillov/easypick.nvim) - Easypick lets you easily create Telescope pickers from arbitrary console commands.
-- [linrongbin16/fzfx.vim](https://github.com/linrongbin16/fzfx.vim) - E(x)tend fzf commands missing in fzf.vim, yet another fzf-based finder focused on better usability and tiny improvements.
+- [linrongbin16/fzfx.vim](https://github.com/linrongbin16/fzfx.vim) - E(x)tend fzf commands missing in fzf.vim,  focused on better usability and tiny improvements.
 
 ### File Explorer
 

--- a/README.md
+++ b/README.md
@@ -292,7 +292,7 @@ You can find them listed on the [Neovim wiki](https://github.com/neovim/neovim/w
 - [jvgrootveld/telescope-zoxide](https://github.com/jvgrootveld/telescope-zoxide) - Telescope integration for [zoxide](https://github.com/ajeetdsouza/zoxide), a smart directory picker that tracks your usage.
 - [echasnovski/mini.nvim#mini.fuzzy](https://github.com/echasnovski/mini.nvim/blob/main/readmes/mini-fuzzy.md) - Module of `mini.nvim` with functions to perform fuzzy matching of one string to others along with fast Telescope sorter.
 - [axkirillov/easypick.nvim](https://github.com/axkirillov/easypick.nvim) - Easypick lets you easily create Telescope pickers from arbitrary console commands.
-- [linrongbin16/fzfx.nvim](https://github.com/linrongbin16/fzfx.nvim) - E(x)tended commands missing in fzf.vim, a brand new plugin build from scratch, focused on usability, customization and performance.
+- [linrongbin16/fzfx.nvim](https://github.com/linrongbin16/fzfx.nvim) - E(x)tended commands missing in fzf.vim, a brand new fzf plugin build from scratch, focused on usability, customization and performance.
 
 ### File Explorer
 


### PR DESCRIPTION
### Repo URL:

https://github.com/linrongbin16/fzfx.nvim

### Checklist:

- [x] The plugin is specifically built for Neovim, or if it's a colorscheme, it supports treesitter syntax.
- [x] The lines end with a `.`. This is to conform to `awesome-list` linting and requirements.
- [x] The title of the pull request is ```Add/Update/Remove `username/repo` ``` (notice the backticks around ``` `username/repo` ```) when adding a new plugin.
- [x] The description doesn't mention that it's a Neovim plugin, it's obvious from the rest of the document. No mentions of the word `plugin` unless it's related to something else.
- [x] The description doesn't contain emojis.
- [x] Neovim is spelled as `Neovim` (not `nvim`, `NeoVim` or `neovim`), Vim is spelled as `Vim` (capitalized), Lua is spelled as `Lua` (capitalized), Tree-sitter is spelled as `Tree-sitter`.
- [x] Acronyms should be fully capitalized, for example `LSP`, `TS`, `YAML`, etc.
