### PR TITLE
Add `dooku.nvim`

### DIFF
--- a/README.md
+++ b/README.md
@@ -889,7 +889,7 @@ These colorschemes may not specialize in Tree-sitter directly but are written in
 - [LudoPinelli/comment-box.nvim](https://github.com/LudoPinelli/comment-box.nvim) - Clarify and beautify your comments using boxes and lines.
 - [JoosepAlviste/nvim-ts-context-commentstring](https://github.com/JoosepAlviste/nvim-ts-context-commentstring) - Sets the `commentstring` option based on the cursor location in the file. The location is checked via treesitter queries.
 - [LucasTavaresA/SingleComment.nvim](https://github.com/LucasTavaresA/SingleComment.nvim) - Always single line, comment sensitive, indentation preserving commenting.
-- [Zeioth/dooku.nvim](https://github.com/Zeioth/dooku.nvim) - Generate and open your HTML code documentation inside Neovim.
+- [Zeioth/dooku.nvim](https://github.com/Zeioth/dooku.nvim) - Generate and open your HTML code documentation.
 
 ### Formatting
 

--- a/README.md
+++ b/README.md
@@ -889,6 +889,7 @@ These colorschemes may not specialize in Tree-sitter directly but are written in
 - [LudoPinelli/comment-box.nvim](https://github.com/LudoPinelli/comment-box.nvim) - Clarify and beautify your comments using boxes and lines.
 - [JoosepAlviste/nvim-ts-context-commentstring](https://github.com/JoosepAlviste/nvim-ts-context-commentstring) - Sets the `commentstring` option based on the cursor location in the file. The location is checked via treesitter queries.
 - [LucasTavaresA/SingleComment.nvim](https://github.com/LucasTavaresA/SingleComment.nvim) - Always single line, comment sensitive, indentation preserving commenting.
+- [Zeioth/dooku.nvim](https://github.com/Zeioth/dooku.nvim) - Generate and open your HTML code documentation inside Neovim.
 
 ### Formatting
 


### PR DESCRIPTION
### Repo URL:

https://github.com/Zeioth/dooku.nvim

### Checklist:

- [ x ] The plugin is specifically built for Neovim, or if it's a colorscheme, it supports treesitter syntax.
- [ x ] The lines end with a `.`. This is to conform to `awesome-list` linting and requirements.
- [ x ] The title of the pull request is ```Add/Update/Remove `username/repo` ``` (notice the backticks around ``` `username/repo` ```) when adding a new plugin.
- [ x ] The description doesn't mention that it's a Neovim plugin, it's obvious from the rest of the document. No mentions of the word `plugin` unless it's related to something else.
- [ x ] The description doesn't contain emojis.
- [ x ] Neovim is spelled as `Neovim` (not `nvim`, `NeoVim` or `neovim`), Vim is spelled as `Vim` (capitalized), Lua is spelled as `Lua` (capitalized), Tree-sitter is spelled as `Tree-sitter`.
- [ x ] Acronyms should be fully capitalized, for example `LSP`, `TS`, `YAML`, etc.
