### PR TITLE
Add `dense-analysis/neural`

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ You can find them listed on the [Neovim wiki](https://github.com/neovim/neovim/w
 - [jackMort/ChatGPT.nvim](https://github.com/jackMort/ChatGPT.nvim) - Effortless Natural Language Generation with OpenAI's ChatGPT API.
 - [CamdenClark/flyboy](https://github.com/CamdenClark/flyboy) - Simple interaction with ChatGPT in a markdown buffer. Supports GPT-4 and Azure OpenAI.
 - [gsuuon/llm.nvim](https://github.com/gsuuon/llm.nvim) - Integrate LLM's via a prompt builder interface. Multi-providers including OpenAI (+ compatibles), PaLM, HuggingFace and local engines like llamacpp.
-- [dense-analysis/neural](https://github.com/dense-analysis/neural) - Integrate LLMs into Neovim for generating code, interacting with chat bots, and more.
+- [dense-analysis/neural](https://github.com/dense-analysis/neural) - Integrate LLMs for generating code, interacting with chat bots, and more.
 
 ### Programming Languages Support
 

--- a/README.md
+++ b/README.md
@@ -188,6 +188,7 @@ You can find them listed on the [Neovim wiki](https://github.com/neovim/neovim/w
 - [jackMort/ChatGPT.nvim](https://github.com/jackMort/ChatGPT.nvim) - Effortless Natural Language Generation with OpenAI's ChatGPT API.
 - [CamdenClark/flyboy](https://github.com/CamdenClark/flyboy) - Simple interaction with ChatGPT in a markdown buffer. Supports GPT-4 and Azure OpenAI.
 - [gsuuon/llm.nvim](https://github.com/gsuuon/llm.nvim) - Integrate LLM's via a prompt builder interface. Multi-providers including OpenAI (+ compatibles), PaLM, HuggingFace and local engines like llamacpp.
+- [dense-analysis/neural](https://github.com/dense-analysis/neural) - Integrate LLMs into Neovim for generating code, interacting with chat bots, and more.
 
 ### Programming Languages Support
 


### PR DESCRIPTION
Add Neural to the AI section, which is undergoing active development and will continue to add more LLM sources and features.

### Repo URL:

https://github.com/dense-analysis/neural

### Checklist:

- [x] The plugin is specifically built for Neovim, or if it's a colorscheme, it supports treesitter syntax.
- [x] The lines end with a `.`. This is to conform to `awesome-list` linting and requirements.
- [x] The title of the pull request is ```Add/Update/Remove `username/repo` ``` (notice the backticks around ``` `username/repo` ```) when adding a new plugin.
- [x] The description doesn't mention that it's a Neovim plugin, it's obvious from the rest of the document. No mentions of the word `plugin` unless it's related to something else.
- [x] The description doesn't contain emojis.
- [x] Neovim is spelled as `Neovim` (not `nvim`, `NeoVim` or `neovim`), Vim is spelled as `Vim` (capitalized), Lua is spelled as `Lua` (capitalized), Tree-sitter is spelled as `Tree-sitter`.
- [x] Acronyms should be fully capitalized, for example `LSP`, `TS`, `YAML`, etc.

### Additional Comments

We use modern Neovim features, such as nui.nvim bells and whistles, while still offering some basic functionality for Vim.