### PR TITLE
Add `chrisgrieser/alfred-neovim-utilities`

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@
 - [External](#external)
   - [Version Manager](#version-manager)
   - [Boilerplate](#boilerplate)
+  - [macOS](#macos)
 - [Vim](#vim)
 - [Resource](#resource)
 

--- a/README.md
+++ b/README.md
@@ -1074,6 +1074,10 @@ These tools are used externally to Neovim to enhance the experience.
 - [m00qek/plugin-template.nvim](https://github.com/m00qek/plugin-template.nvim) - A plugin template that setups test infrastructure and GitHub Actions.
 - [ellisonleao/nvim-plugin-template](https://github.com/ellisonleao/nvim-plugin-template) - Another neovim plugin template, using GitHub's template feature.
 
+### macOS
+
+- [chrisgrieser/alfred-neovim-utilities](https://github.com/chrisgrieser/alfred-neovim-utilities) - Search Neovim plugins and online `:help `via Alfred.
+
 ## Vim
 
 - [Vimawesome](https://vimawesome.com/) - Showcases various plugins for Vim and has a [neovim tag](https://vimawesome.com/?q=tag:neovim) for other plugins targeting Neovim.

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@
 - [External](#external)
   - [Version Manager](#version-manager)
   - [Boilerplate](#boilerplate)
-  - [macOS](#macos)
+  - [OS-specific](#os-specific)
 - [Vim](#vim)
 - [Resource](#resource)
 
@@ -1075,9 +1075,9 @@ These tools are used externally to Neovim to enhance the experience.
 - [m00qek/plugin-template.nvim](https://github.com/m00qek/plugin-template.nvim) - A plugin template that setups test infrastructure and GitHub Actions.
 - [ellisonleao/nvim-plugin-template](https://github.com/ellisonleao/nvim-plugin-template) - Another neovim plugin template, using GitHub's template feature.
 
-### macOS
+### OS-specific
 
-- [chrisgrieser/alfred-neovim-utilities](https://github.com/chrisgrieser/alfred-neovim-utilities) - Search Neovim plugins and online `:help `via Alfred.
+- [chrisgrieser/alfred-neovim-utilities](https://github.com/chrisgrieser/alfred-neovim-utilities) - Search Neovim plugins and online `:help `via Alfred (macOS).
 
 ## Vim
 


### PR DESCRIPTION
I created a new h3 heading, since it's an external tool that neither fits into "version manager" nor "boilerplate" – hope that's alright?

### Repo URL:

https://github.com/chrisgrieser/alfred-neovim-utilities

### Checklist:

- [x] The plugin is specifically built for Neovim, or if it's a colorscheme, it supports treesitter syntax.
- [x] The lines end with a `.`. This is to conform to `awesome-list` linting and requirements.
- [x] The title of the pull request is ```Add/Update/Remove `username/repo` ``` (notice the backticks around ``` `username/repo` ```) when adding a new plugin.
- [x] The description doesn't mention that it's a Neovim plugin, it's obvious from the rest of the document. No mentions of the word `plugin` unless it's related to something else.
- [x] The description doesn't contain emojis.
- [x] Neovim is spelled as `Neovim` (not `nvim`, `NeoVim` or `neovim`), Vim is spelled as `Vim` (capitalized), Lua is spelled as `Lua` (capitalized), Tree-sitter is spelled as `Tree-sitter`.
- [x] Acronyms should be fully capitalized, for example `LSP`, `TS`, `YAML`, etc.
