### PR TITLE
Add `VidocqH/data-viewer.nvim`

### DIFF
--- a/README.md
+++ b/README.md
@@ -662,6 +662,7 @@ These colorschemes may not specialize in Tree-sitter directly but are written in
 - [GCBallesteros/NotebookNavigator.nvim](https://github.com/GCBallesteros/NotebookNavigator.nvim) - Navigate and execute code cells.
 - [LintaoAmons/scratch.nvim](https://github.com/LintaoAmons/scratch.nvim) - Create and manage scratch files.
 - [luckasRanarison/nvim-devdocs](https://github.com/luckasRanarison/nvim-devdocs) - Preview devdocs.io documentations directly in Markdown format.
+- [VidocqH/data-viewer.nvim](https://github.com/VidocqH/data-viewer.nvim) - Lightweight plugin for providing a simple table view to inspect data files such as `csv`, `tsv`.
 
 ### Terminal Integration
 

--- a/README.md
+++ b/README.md
@@ -662,7 +662,7 @@ These colorschemes may not specialize in Tree-sitter directly but are written in
 - [GCBallesteros/NotebookNavigator.nvim](https://github.com/GCBallesteros/NotebookNavigator.nvim) - Navigate and execute code cells.
 - [LintaoAmons/scratch.nvim](https://github.com/LintaoAmons/scratch.nvim) - Create and manage scratch files.
 - [luckasRanarison/nvim-devdocs](https://github.com/luckasRanarison/nvim-devdocs) - Preview devdocs.io documentations directly in Markdown format.
-- [VidocqH/data-viewer.nvim](https://github.com/VidocqH/data-viewer.nvim) - Lightweight plugin for providing a simple table view to inspect data files such as `csv`, `tsv`.
+- [VidocqH/data-viewer.nvim](https://github.com/VidocqH/data-viewer.nvim) - Provide a simple table view to inspect data files such as `csv`, `tsv`.
 
 ### Terminal Integration
 


### PR DESCRIPTION
### Repo URL:

https://github.com/VidocqH/data-viewer.nvim

### Checklist:

- [x] The plugin is specifically built for Neovim, or if it's a colorscheme, it supports treesitter syntax.
- [x] The lines end with a `.`. This is to conform to `awesome-list` linting and requirements.
- [x] The title of the pull request is ```Add/Update/Remove `username/repo` ``` (notice the backticks around ``` `username/repo` ```) when adding a new plugin.
- [ ] The description doesn't mention that it's a Neovim plugin, it's obvious from the rest of the document. No mentions of the word `plugin` unless it's related to something else.
- [x] The description doesn't contain emojis.
- [x] Neovim is spelled as `Neovim` (not `nvim`, `NeoVim` or `neovim`), Vim is spelled as `Vim` (capitalized), Lua is spelled as `Lua` (capitalized), Tree-sitter is spelled as `Tree-sitter`.
- [x] Acronyms should be fully capitalized, for example `LSP`, `TS`, `YAML`, etc.
