### PR TITLE
Add `oxfist/night-owl.nvim`

### DIFF
--- a/README.md
+++ b/README.md
@@ -454,6 +454,7 @@ Tree-sitter is a new system introduced in Neovim 0.5 that incrementally parses y
 - [ribru17/bamboo.nvim](https://github.com/ribru17/bamboo.nvim) - A warm green theme.
 - [cryptomilk/nightcity.nvim](https://github.com/cryptomilk/nightcity.nvim) - A dark colorscheme inspired by Inkpot, Jellybeans, Gruvbox and Tokyonight with LSP support.
 - [polirritmico/monokai-nightasty.nvim](https://github.com/polirritmico/monokai-nightasty.nvim) - A dark/light theme based on the Monokai color palette written in Lua, support for LSP, Tree-sitter and lots of plugins.
+- [oxfist/night-owl.nvim](https://github.com/oxfist/night-owl.nvim) A Night Owl colorscheme implementation for Neovim with support for Treesitter and semantic tokens .
 
 ### Lua Colorscheme
 

--- a/README.md
+++ b/README.md
@@ -454,7 +454,7 @@ Tree-sitter is a new system introduced in Neovim 0.5 that incrementally parses y
 - [ribru17/bamboo.nvim](https://github.com/ribru17/bamboo.nvim) - A warm green theme.
 - [cryptomilk/nightcity.nvim](https://github.com/cryptomilk/nightcity.nvim) - A dark colorscheme inspired by Inkpot, Jellybeans, Gruvbox and Tokyonight with LSP support.
 - [polirritmico/monokai-nightasty.nvim](https://github.com/polirritmico/monokai-nightasty.nvim) - A dark/light theme based on the Monokai color palette written in Lua, support for LSP, Tree-sitter and lots of plugins.
-- [oxfist/night-owl.nvim](https://github.com/oxfist/night-owl.nvim) - A [Night Owl colorscheme port from VSCode](https://github.com/sdras/night-owl-vscode-theme) to Neovim with support for Tree-sitter and semantic tokens.
+- [oxfist/night-owl.nvim](https://github.com/oxfist/night-owl.nvim) - A [Night Owl colorscheme port from VSCode](https://github.com/sdras/night-owl-vscode-theme) with support for Tree-sitter and semantic tokens.
 
 ### Lua Colorscheme
 

--- a/README.md
+++ b/README.md
@@ -454,7 +454,7 @@ Tree-sitter is a new system introduced in Neovim 0.5 that incrementally parses y
 - [ribru17/bamboo.nvim](https://github.com/ribru17/bamboo.nvim) - A warm green theme.
 - [cryptomilk/nightcity.nvim](https://github.com/cryptomilk/nightcity.nvim) - A dark colorscheme inspired by Inkpot, Jellybeans, Gruvbox and Tokyonight with LSP support.
 - [polirritmico/monokai-nightasty.nvim](https://github.com/polirritmico/monokai-nightasty.nvim) - A dark/light theme based on the Monokai color palette written in Lua, support for LSP, Tree-sitter and lots of plugins.
-- [oxfist/night-owl.nvim](https://github.com/oxfist/night-owl.nvim) A Night Owl colorscheme implementation for Neovim with support for Treesitter and semantic tokens .
+- [oxfist/night-owl.nvim](https://github.com/oxfist/night-owl.nvim) A [Night Owl colorscheme port](https://github.com/sdras/night-owl-vscode-theme) from VSCCode with support for Treesitter and semantic tokens.
 
 ### Lua Colorscheme
 

--- a/README.md
+++ b/README.md
@@ -454,7 +454,7 @@ Tree-sitter is a new system introduced in Neovim 0.5 that incrementally parses y
 - [ribru17/bamboo.nvim](https://github.com/ribru17/bamboo.nvim) - A warm green theme.
 - [cryptomilk/nightcity.nvim](https://github.com/cryptomilk/nightcity.nvim) - A dark colorscheme inspired by Inkpot, Jellybeans, Gruvbox and Tokyonight with LSP support.
 - [polirritmico/monokai-nightasty.nvim](https://github.com/polirritmico/monokai-nightasty.nvim) - A dark/light theme based on the Monokai color palette written in Lua, support for LSP, Tree-sitter and lots of plugins.
-- [oxfist/night-owl.nvim](https://github.com/oxfist/night-owl.nvim) A [Night Owl colorscheme port](https://github.com/sdras/night-owl-vscode-theme) from VSCode with support for Treesitter and semantic tokens.
+- [oxfist/night-owl.nvim](https://github.com/oxfist/night-owl.nvim) A [Night Owl colorscheme port from VSCode](https://github.com/sdras/night-owl-vscode-theme) to Neovim with support for Tree-sitter and semantic tokens.
 
 ### Lua Colorscheme
 

--- a/README.md
+++ b/README.md
@@ -454,7 +454,7 @@ Tree-sitter is a new system introduced in Neovim 0.5 that incrementally parses y
 - [ribru17/bamboo.nvim](https://github.com/ribru17/bamboo.nvim) - A warm green theme.
 - [cryptomilk/nightcity.nvim](https://github.com/cryptomilk/nightcity.nvim) - A dark colorscheme inspired by Inkpot, Jellybeans, Gruvbox and Tokyonight with LSP support.
 - [polirritmico/monokai-nightasty.nvim](https://github.com/polirritmico/monokai-nightasty.nvim) - A dark/light theme based on the Monokai color palette written in Lua, support for LSP, Tree-sitter and lots of plugins.
-- [oxfist/night-owl.nvim](https://github.com/oxfist/night-owl.nvim) A [Night Owl colorscheme port](https://github.com/sdras/night-owl-vscode-theme) from VSCCode with support for Treesitter and semantic tokens.
+- [oxfist/night-owl.nvim](https://github.com/oxfist/night-owl.nvim) A [Night Owl colorscheme port](https://github.com/sdras/night-owl-vscode-theme) from VSCode with support for Treesitter and semantic tokens.
 
 ### Lua Colorscheme
 

--- a/README.md
+++ b/README.md
@@ -454,7 +454,7 @@ Tree-sitter is a new system introduced in Neovim 0.5 that incrementally parses y
 - [ribru17/bamboo.nvim](https://github.com/ribru17/bamboo.nvim) - A warm green theme.
 - [cryptomilk/nightcity.nvim](https://github.com/cryptomilk/nightcity.nvim) - A dark colorscheme inspired by Inkpot, Jellybeans, Gruvbox and Tokyonight with LSP support.
 - [polirritmico/monokai-nightasty.nvim](https://github.com/polirritmico/monokai-nightasty.nvim) - A dark/light theme based on the Monokai color palette written in Lua, support for LSP, Tree-sitter and lots of plugins.
-- [oxfist/night-owl.nvim](https://github.com/oxfist/night-owl.nvim) A [Night Owl colorscheme port from VSCode](https://github.com/sdras/night-owl-vscode-theme) to Neovim with support for Tree-sitter and semantic tokens.
+- [oxfist/night-owl.nvim](https://github.com/oxfist/night-owl.nvim) - A [Night Owl colorscheme port from VSCode](https://github.com/sdras/night-owl-vscode-theme) to Neovim with support for Tree-sitter and semantic tokens.
 
 ### Lua Colorscheme
 


### PR DESCRIPTION
### Repo URL:

https://github.com/oxfist/night-owl.nvim

### Checklist:

- [X] The plugin is specifically built for Neovim, or if it's a colorscheme, it supports treesitter syntax.
- [X] The lines end with a `.`. This is to conform to `awesome-list` linting and requirements.
- [X] The title of the pull request is ```Add/Update/Remove `username/repo` ``` (notice the backticks around ``` `username/repo` ```) when adding a new plugin.
- [X] The description doesn't mention that it's a Neovim plugin, it's obvious from the rest of the document. No mentions of the word `plugin` unless it's related to something else.
- [X] The description doesn't contain emojis.
- [X] Neovim is spelled as `Neovim` (not `nvim`, `NeoVim` or `neovim`), Vim is spelled as `Vim` (capitalized), Lua is spelled as `Lua` (capitalized), Tree-sitter is spelled as `Tree-sitter`.
- [X] Acronyms should be fully capitalized, for example `LSP`, `TS`, `YAML`, etc.

