### PR TITLE
Add `linrongbin16/colorbox.nvim`

### DIFF
--- a/README.md
+++ b/README.md
@@ -507,7 +507,7 @@ These colorschemes may not specialize in Tree-sitter directly but are written in
 - [4e554c4c/darkman.nvim](https://github.com/4e554c4c/darkman.nvim) - Follow the system dark-mode setting on Linux.
 - [f-person/auto-dark-mode.nvim](https://github.com/f-person/auto-dark-mode.nvim) - Follow the system appearance on macOS.
 - [zaldih/themery.nvim](https://github.com/zaldih/themery.nvim) - A new way to change the colorscheme on the fly like in vscode.
-- [linrongbin16/colorbox.nvim](https://github.com/linrongbin16/colorbox.nvim) - Ultra colors all-in-one! Are you greedy that you want all the most popurlar Vim/Neovim colorschemes? Are you playful that you change colorscheme from time to time? This is it! It use offline GitHub actions to weekly collect and update the most popurlar colorschemes list, install them via git submodules instead of copy-paste source code (e.g. you can get continuously updates from the original author instead of me), and allow you do any switches with multiple policies and timings.
+- [linrongbin16/colorbox.nvim](https://github.com/linrongbin16/colorbox.nvim) - Ultra colors all-in-one! It weekly collect and update the most popurlar colorschemes, install them via git submodules instead of copy-paste source code, and allow you do any switches with multiple policies and timings.
 
 ## Bars and Lines
 

--- a/README.md
+++ b/README.md
@@ -507,7 +507,7 @@ These colorschemes may not specialize in Tree-sitter directly but are written in
 - [4e554c4c/darkman.nvim](https://github.com/4e554c4c/darkman.nvim) - Follow the system dark-mode setting on Linux.
 - [f-person/auto-dark-mode.nvim](https://github.com/f-person/auto-dark-mode.nvim) - Follow the system appearance on macOS.
 - [zaldih/themery.nvim](https://github.com/zaldih/themery.nvim) - A new way to change the colorscheme on the fly like in vscode.
-- [linrongbin16/colorbox.nvim](https://github.com/linrongbin16/colorbox.nvim) - Are you greedy that want all the most popurlar Vim/Neovim colorschemes? Are you playful that change colorscheme from time to time? This is it! It use offline GitHub actions to weekly collect and update the most popurlar colorschemes list, install them via git submodules instead of copy-paste source code (e.g. you can get continuously updates from the original author instead of me), and allow you do any switches with multiple policies and timings.
+- [linrongbin16/colorbox.nvim](https://github.com/linrongbin16/colorbox.nvim) - Are you greedy that you want all the most popurlar Vim/Neovim colorschemes? Are you playful that you change colorscheme from time to time? This is it! It use offline GitHub actions to weekly collect and update the most popurlar colorschemes list, install them via git submodules instead of copy-paste source code (e.g. you can get continuously updates from the original author instead of me), and allow you do any switches with multiple policies and timings.
 
 ## Bars and Lines
 

--- a/README.md
+++ b/README.md
@@ -507,7 +507,7 @@ These colorschemes may not specialize in Tree-sitter directly but are written in
 - [4e554c4c/darkman.nvim](https://github.com/4e554c4c/darkman.nvim) - Follow the system dark-mode setting on Linux.
 - [f-person/auto-dark-mode.nvim](https://github.com/f-person/auto-dark-mode.nvim) - Follow the system appearance on macOS.
 - [zaldih/themery.nvim](https://github.com/zaldih/themery.nvim) - A new way to change the colorscheme on the fly like in vscode.
-- [linrongbin16/colorbox.nvim](https://github.com/linrongbin16/colorbox.nvim) - Are you greedy that you want all the most popurlar Vim/Neovim colorschemes? Are you playful that you change colorscheme from time to time? This is it! It use offline GitHub actions to weekly collect and update the most popurlar colorschemes list, install them via git submodules instead of copy-paste source code (e.g. you can get continuously updates from the original author instead of me), and allow you do any switches with multiple policies and timings.
+- [linrongbin16/colorbox.nvim](https://github.com/linrongbin16/colorbox.nvim) - Ultra colors all-in-one! Are you greedy that you want all the most popurlar Vim/Neovim colorschemes? Are you playful that you change colorscheme from time to time? This is it! It use offline GitHub actions to weekly collect and update the most popurlar colorschemes list, install them via git submodules instead of copy-paste source code (e.g. you can get continuously updates from the original author instead of me), and allow you do any switches with multiple policies and timings.
 
 ## Bars and Lines
 

--- a/README.md
+++ b/README.md
@@ -507,6 +507,7 @@ These colorschemes may not specialize in Tree-sitter directly but are written in
 - [4e554c4c/darkman.nvim](https://github.com/4e554c4c/darkman.nvim) - Follow the system dark-mode setting on Linux.
 - [f-person/auto-dark-mode.nvim](https://github.com/f-person/auto-dark-mode.nvim) - Follow the system appearance on macOS.
 - [zaldih/themery.nvim](https://github.com/zaldih/themery.nvim) - A new way to change the colorscheme on the fly like in vscode.
+- [linrongbin16/colorbox.nvim](https://github.com/linrongbin16/colorbox.nvim) - Ultra colors all-in-one. Are you greedy that want all the most popurlar Vim/Neovim colorschemes? Are you playful that change colorscheme from time to time? This is it! It use offline github actions to weekly collect and update a most popurlar Vim/Neovim colorschemes list, install them via git submodules instead of copy-paste source code (e.g. you can get continuously updates from the original author instead of me), allow you do any switches with multiple policies and multiple timing.
 
 ## Bars and Lines
 

--- a/README.md
+++ b/README.md
@@ -507,7 +507,7 @@ These colorschemes may not specialize in Tree-sitter directly but are written in
 - [4e554c4c/darkman.nvim](https://github.com/4e554c4c/darkman.nvim) - Follow the system dark-mode setting on Linux.
 - [f-person/auto-dark-mode.nvim](https://github.com/f-person/auto-dark-mode.nvim) - Follow the system appearance on macOS.
 - [zaldih/themery.nvim](https://github.com/zaldih/themery.nvim) - A new way to change the colorscheme on the fly like in vscode.
-- [linrongbin16/colorbox.nvim](https://github.com/linrongbin16/colorbox.nvim) - Ultra colors all-in-one. Are you greedy that want all the most popurlar Vim/Neovim colorschemes? Are you playful that change colorscheme from time to time? This is it! It use offline github actions to weekly collect and update a most popurlar Vim/Neovim colorschemes list, install them via git submodules instead of copy-paste source code (e.g. you can get continuously updates from the original author instead of me), allow you do any switches with multiple policies and multiple timing.
+- [linrongbin16/colorbox.nvim](https://github.com/linrongbin16/colorbox.nvim) - Are you greedy that want all the most popurlar Vim/Neovim colorschemes? Are you playful that change colorscheme from time to time? This is it! It use offline github actions to weekly collect and update the most popurlar colorschemes list, install them via git submodules instead of copy-paste source code (e.g. you can get continuously updates from the original author instead of me), and allow you do any switches with multiple policies and timings.
 
 ## Bars and Lines
 

--- a/README.md
+++ b/README.md
@@ -507,7 +507,7 @@ These colorschemes may not specialize in Tree-sitter directly but are written in
 - [4e554c4c/darkman.nvim](https://github.com/4e554c4c/darkman.nvim) - Follow the system dark-mode setting on Linux.
 - [f-person/auto-dark-mode.nvim](https://github.com/f-person/auto-dark-mode.nvim) - Follow the system appearance on macOS.
 - [zaldih/themery.nvim](https://github.com/zaldih/themery.nvim) - A new way to change the colorscheme on the fly like in vscode.
-- [linrongbin16/colorbox.nvim](https://github.com/linrongbin16/colorbox.nvim) - Are you greedy that want all the most popurlar Vim/Neovim colorschemes? Are you playful that change colorscheme from time to time? This is it! It use offline github actions to weekly collect and update the most popurlar colorschemes list, install them via git submodules instead of copy-paste source code (e.g. you can get continuously updates from the original author instead of me), and allow you do any switches with multiple policies and timings.
+- [linrongbin16/colorbox.nvim](https://github.com/linrongbin16/colorbox.nvim) - Are you greedy that want all the most popurlar Vim/Neovim colorschemes? Are you playful that change colorscheme from time to time? This is it! It use offline Github actions to weekly collect and update the most popurlar colorschemes list, install them via git submodules instead of copy-paste source code (e.g. you can get continuously updates from the original author instead of me), and allow you do any switches with multiple policies and timings.
 
 ## Bars and Lines
 

--- a/README.md
+++ b/README.md
@@ -507,7 +507,7 @@ These colorschemes may not specialize in Tree-sitter directly but are written in
 - [4e554c4c/darkman.nvim](https://github.com/4e554c4c/darkman.nvim) - Follow the system dark-mode setting on Linux.
 - [f-person/auto-dark-mode.nvim](https://github.com/f-person/auto-dark-mode.nvim) - Follow the system appearance on macOS.
 - [zaldih/themery.nvim](https://github.com/zaldih/themery.nvim) - A new way to change the colorscheme on the fly like in vscode.
-- [linrongbin16/colorbox.nvim](https://github.com/linrongbin16/colorbox.nvim) - Are you greedy that want all the most popurlar Vim/Neovim colorschemes? Are you playful that change colorscheme from time to time? This is it! It use offline Github actions to weekly collect and update the most popurlar colorschemes list, install them via git submodules instead of copy-paste source code (e.g. you can get continuously updates from the original author instead of me), and allow you do any switches with multiple policies and timings.
+- [linrongbin16/colorbox.nvim](https://github.com/linrongbin16/colorbox.nvim) - Are you greedy that want all the most popurlar Vim/Neovim colorschemes? Are you playful that change colorscheme from time to time? This is it! It use offline GitHub actions to weekly collect and update the most popurlar colorschemes list, install them via git submodules instead of copy-paste source code (e.g. you can get continuously updates from the original author instead of me), and allow you do any switches with multiple policies and timings.
 
 ## Bars and Lines
 


### PR DESCRIPTION
### Repo URL:

https://github.com/linrongbin16/colorbox.nvim

### Checklist:

- [x] The plugin is specifically built for Neovim, or if it's a colorscheme, it supports treesitter syntax.
- [x] The lines end with a `.`. This is to conform to `awesome-list` linting and requirements.
- [x] The title of the pull request is ```Add/Update/Remove `username/repo` ``` (notice the backticks around ``` `username/repo` ```) when adding a new plugin.
- [x] The description doesn't mention that it's a Neovim plugin, it's obvious from the rest of the document. No mentions of the word `plugin` unless it's related to something else.
- [x] The description doesn't contain emojis.
- [x] Neovim is spelled as `Neovim` (not `nvim`, `NeoVim` or `neovim`), Vim is spelled as `Vim` (capitalized), Lua is spelled as `Lua` (capitalized), Tree-sitter is spelled as `Tree-sitter`.
- [x] Acronyms should be fully capitalized, for example `LSP`, `TS`, `YAML`, etc.
