### PR TITLE
Remove `weilbith/nvim-code-action-menu`

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,6 @@
 - [tamago324/nlsp-settings.nvim](https://github.com/tamago324/nlsp-settings.nvim) - Setup LSP with JSON or YAML files.
 - [jakewvincent/texmagic.nvim](https://github.com/jakewvincent/texmagic.nvim) - Enhance the lspconfig settings for Texlab by defining any number of custom LaTeX build engines and selecting them with magic comments.
 - [nanotee/nvim-lsp-basics](https://github.com/nanotee/nvim-lsp-basics) - Basic wrappers for LSP features.
-- [weilbith/nvim-code-action-menu](https://github.com/weilbith/nvim-code-action-menu) - A floating pop-up menu for code actions to show code action information and a diff preview.
 - [aznhe21/actions-preview.nvim](https://github.com/aznhe21/actions-preview.nvim) - Fully customizable previewer for LSP code actions.
 - [mfussenegger/nvim-lint](https://github.com/mfussenegger/nvim-lint) - An asynchronous linter plugin, complementary to the built-in Language Server Protocol support.
 - [b0o/SchemaStore.nvim](https://github.com/b0o/SchemaStore.nvim) - Provide access to the [SchemaStore](https://github.com/SchemaStore/schemastore) catalog.


### PR DESCRIPTION
Sadly, the GitHub repo of the  [`weilbith/nvim-code-action-menu`](https://github.com/weilbith/nvim-code-action-menu) plugin has been archived 2 weeks ago, so I removed it from the list in this PR.

See this commit: https://github.com/weilbith/nvim-code-action-menu/commit/8c7672a4b04d3cc4edd2c484d05b660a9cb34a1b