### PR TITLE
Update README.md to reflect list policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 [![Awesome](https://awesome.re/badge-flat.svg)](https://awesome.re)
 -->
 
-> Collections of awesome Neovim plugins. Mostly targeting Neovim specific features.
+> Collections of awesome Neovim plugins. Mostly targeting Neovim specific features. This means vim-compatible plugins are not listed here.
 
 [Neovim](https://neovim.io/) is a Vim-based text editor engineered for extensibility and usability, to encourage new applications and contributions.
 


### PR DESCRIPTION
As per #574, vim-compatible plugins are not listed in this list. The README says that this list is for plugins "mostly targeting neovim-specific features". We should update the description to avoid confusion.