### PR TITLE
Add `massix/termux.nvim`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1192,6 +1192,7 @@ These tools are used externally to Neovim to enhance the experience.
 ### OS-specific
 
 - [chrisgrieser/alfred-neovim-utilities](https://github.com/chrisgrieser/alfred-neovim-utilities) - Search Neovim plugins and online `:help `via Alfred (macOS).
+- [massix/termux.nvim](https://github.com/massix/termux.nvim) - Interact with Termux APIs from Neovim, useful to gather various information about your Android phone to display in the statusline (e.g. battery level).
 
 ## Wishlist
 

--- a/README.md
+++ b/README.md
@@ -1192,7 +1192,7 @@ These tools are used externally to Neovim to enhance the experience.
 ### OS-specific
 
 - [chrisgrieser/alfred-neovim-utilities](https://github.com/chrisgrieser/alfred-neovim-utilities) - Search Neovim plugins and online `:help `via Alfred (macOS).
-- [massix/termux.nvim](https://github.com/massix/termux.nvim) - Interact with Termux APIs from Neovim, useful to gather various information about your Android phone to display in the statusline (e.g. battery level).
+- [massix/termux.nvim](https://github.com/massix/termux.nvim) - Interact with Termux APIs, useful to gather various information about your Android phone to display in the statusline (e.g. battery level).
 
 ## Wishlist
 


### PR DESCRIPTION
### Repo URL:

https://github.com/massix/termux.nvim

### Checklist:

- [X] The plugin is specifically built for Neovim, or if it's a colorscheme, it supports treesitter syntax.
- [X] The lines end with a `.`. This is to conform to `awesome-list` linting and requirements.
- [X] The title of the pull request is ```Add/Update/Remove `username/repo` ``` (notice the backticks around ``` `username/repo` ```) when adding a new plugin.
- [X] The description doesn't mention that it's a Neovim plugin, it's obvious from the rest of the document. No mentions of the word `plugin` unless it's related to something else.
- [X] The description doesn't contain emojis.
- [X] Neovim is spelled as `Neovim` (not `nvim`, `NeoVim` or `neovim`), Vim is spelled as `Vim` (capitalized), Lua is spelled as `Lua` (capitalized), Tree-sitter is spelled as `Tree-sitter`.
- [X] Acronyms should be fully capitalized, for example `LSP`, `TS`, `YAML`, etc.
