### PR TITLE
Add `fnune/recall.nvim`

### DIFF
--- a/README.md
+++ b/README.md
@@ -321,6 +321,7 @@
 - [tomasky/bookmarks.nvim](https://github.com/tomasky/bookmarks.nvim) - Bookmarks with global file storage, written in Lua.
 - [LintaoAmons/bookmarks.nvim](https://github.com/LintaoAmons/bookmarks.nvim) - Your new bookmarks option: simple yet powerful.
 - [desdic/marlin.nvim](https://github.com/desdic/marlin.nvim) - Like harpoon, but with key differences like project path, split support, no UI.
+- [fnune/recall.nvim](https://github.com/fnune/recall.nvim) - Recall refines the use of Neovim marks by focusing on global marks, streamlining their usage and enhancing their visibility and navigability. 
 
 ## Search
 

--- a/README.md
+++ b/README.md
@@ -321,7 +321,7 @@
 - [tomasky/bookmarks.nvim](https://github.com/tomasky/bookmarks.nvim) - Bookmarks with global file storage, written in Lua.
 - [LintaoAmons/bookmarks.nvim](https://github.com/LintaoAmons/bookmarks.nvim) - Your new bookmarks option: simple yet powerful.
 - [desdic/marlin.nvim](https://github.com/desdic/marlin.nvim) - Like harpoon, but with key differences like project path, split support, no UI.
-- [fnune/recall.nvim](https://github.com/fnune/recall.nvim) - Recall refines the use of Neovim marks by focusing on global marks, streamlining their usage and enhancing their visibility and navigability. 
+- [fnune/recall.nvim](https://github.com/fnune/recall.nvim) - Recall refines the use of marks by focusing on global marks, streamlining their usage and enhancing their visibility and navigability. 
 
 ## Search
 


### PR DESCRIPTION
Hi! I've spent some time creating https://github.com/fnune/recall.nvim/

It does exactly what I needed in terms of managing marks in an easier way in Neovim, and focusing on global marks (the only ones I care about).

This PR adds it to the `Marks` section.

### Repo URL:

https://github.com/fnune/recall.nvim

### Checklist:

- [x] The plugin is specifically built for Neovim, or if it's a colorscheme, it supports treesitter syntax.
- [x] The lines end with a `.`. This is to conform to `awesome-list` linting and requirements.
- [x] The title of the pull request is ```Add/Update/Remove `username/repo` ``` (notice the backticks around ``` `username/repo` ```) when adding a new plugin.
- [x] The description doesn't mention that it's a Neovim plugin, it's obvious from the rest of the document. No mentions of the word `plugin` unless it's related to something else.
- [x] The description doesn't contain emojis.
- [x] Neovim is spelled as `Neovim` (not `nvim`, `NeoVim` or `neovim`), Vim is spelled as `Vim` (capitalized), Lua is spelled as `Lua` (capitalized), Tree-sitter is spelled as `Tree-sitter`.
- [x] Acronyms should be fully capitalized, for example `LSP`, `TS`, `YAML`, etc.
