### PR TITLE
Add `gerardbm/vim-atomic`

### DIFF
--- a/README.md
+++ b/README.md
@@ -537,6 +537,7 @@ Tree-sitter is a new system introduced in Neovim 0.5 that incrementally parses y
 - [loganswartz/sunburn.nvim](https://github.com/loganswartz/sunburn.nvim) - A colorscheme sitting somewhere between pastels and solarized, emphasizing readability and hue uniformity above all else.
 - [ptdewey/darkearth-nvim](https://github.com/ptdewey/darkearth-nvim) - A dark and earthy colorscheme supporting Tree-sitter and LSP.
 - [uloco/bluloco.nvim](https://github.com/uloco/bluloco.nvim) - A dark and earthy colorscheme supporting Tree-sitter and LSP.
+- [gerardbm/vim-atomic](https://github.com/gerardbm/vim-atomic) - Vim-atomic is a dark & light color scheme designed to use on vim, gvim and neovim.
 
 ### Lua Colorscheme
 


### PR DESCRIPTION
Github Repo:
- https://github.com/gerardbm/vim-atomic

### Repo URL:

https://github.com/gerardbm/vim-atomic

### Checklist:

- [x] The plugin is specifically built for Neovim, or if it's a colorscheme, it supports treesitter syntax.
- [x] The lines end with a `.`. This is to conform to `awesome-list` linting and requirements.
- [x] The title of the pull request is ```Add/Update/Remove `username/repo` ``` (notice the backticks around ``` `username/repo` ```) when adding a new plugin.
- [x] The description doesn't mention that it's a Neovim plugin, it's obvious from the rest of the document. No mentions of the word `plugin` unless it's related to something else. No `.. for Neovim`.
- [x] The description doesn't contain emojis.
- [x] Neovim is spelled as `Neovim` (not `nvim`, `NeoVim` or `neovim`), Vim is spelled as `Vim` (capitalized), Lua is spelled as `Lua` (capitalized), Tree-sitter is spelled as `Tree-sitter`.
- [x] Acronyms should be fully capitalized, for example `LSP`, `TS`, `YAML`, etc.
