### PR TITLE
Add `CopilotC-Nvim/CopilotChat.nvim`

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,7 @@
 - [olimorris/codecompanion.nvim](https://github.com/olimorris/codecompanion.nvim) - Copilot chat like experience via a buffer. Supports Anthropic, Ollama and OpenAI.
 - [simplegpt.nvim](https://github.com/you-n-g/simplegpt.nvim) - Provide a simple yet flexible way to construct and send questions to ChatGPT.
 - [Exafunction/codeium.nvim](https://github.com/Exafunction/codeium.nvim) - Free, ultrafast Copilot alternative. Supports LSP and Tree-sitter.
+- [CopilotC-Nvim/CopilotChat.nvim](https://github.com/CopilotC-Nvim/CopilotChat.nvim) - A chat interface for GitHub Copilot that allows you to directly ask and receive answers to coding-related questions.
 
 ## Programming Languages Support
 


### PR DESCRIPTION
### Repo URL:

https://github.com/CopilotC-Nvim/CopilotChat.nvim

### Checklist:

- [x] The plugin is specifically built for Neovim, or if it's a colorscheme, it supports treesitter syntax.
- [x] The lines end with a `.`. This is to conform to `awesome-list` linting and requirements.
- [x] The title of the pull request is ```Add/Update/Remove `username/repo` ``` (notice the backticks around ``` `username/repo` ```) when adding a new plugin.
- [x] The description doesn't mention that it's a Neovim plugin, it's obvious from the rest of the document. No mentions of the word `plugin` unless it's related to something else. No `.. for Neovim`.
- [x] The description doesn't contain emojis.
- [x] Neovim is spelled as `Neovim` (not `nvim`, `NeoVim` or `neovim`), Vim is spelled as `Vim` (capitalized), Lua is spelled as `Lua` (capitalized), Tree-sitter is spelled as `Tree-sitter`.
- [x] Acronyms should be fully capitalized, for example `LSP`, `TS`, `YAML`, etc.
