### PR TITLE
Add `MagicDuck/grug-far.nvim`

### DIFF
--- a/README.md
+++ b/README.md
@@ -351,7 +351,7 @@
 - [FabianWirth/search.nvim](https://github.com/FabianWirth/search.nvim) - Tabs for different Telescope pickers.
 - [backdround/improved-search.nvim](https://github.com/backdround/improved-search.nvim) - Add search abilities.
 - [polirritmico/telescope-lazy-plugins.nvim](https://github.com/polirritmico/telescope-lazy-plugins.nvim) - A Telescope picker to quickly access plugins configurations from the lazy.nvim spec.
-- [MagicDuck/grug-far.nvim](https://github.com/MagicDuck/grug-far.nvim) - Buffer-based live search and replace with full power of `rg` flags. Sync inline edits to results. Load searches from history. Grug like!
+- [MagicDuck/grug-far.nvim](https://github.com/MagicDuck/grug-far.nvim) - Buffer-based live search and replace with full power of `rg` flags. Sync inline edits to results. Load searches from history. Grug like!.
 
 ## Fuzzy Finder
 

--- a/README.md
+++ b/README.md
@@ -351,6 +351,7 @@
 - [FabianWirth/search.nvim](https://github.com/FabianWirth/search.nvim) - Tabs for different Telescope pickers.
 - [backdround/improved-search.nvim](https://github.com/backdround/improved-search.nvim) - Add search abilities.
 - [polirritmico/telescope-lazy-plugins.nvim](https://github.com/polirritmico/telescope-lazy-plugins.nvim) - A Telescope picker to quickly access plugins configurations from the lazy.nvim spec.
+- [MagicDuck/grug-far.nvim](https://github.com/MagicDuck/grug-far.nvim) - Buffer-based live search and replace with full power of `rg` flags. Sync inline edits to results. Load searches from history. Grug like!
 
 ## Fuzzy Finder
 


### PR DESCRIPTION
### Repo URL:

https://github.com/MagicDuck/grug-far.nvim

### Checklist:

- [ ] The plugin is specifically built for Neovim, or if it's a colorscheme, it supports treesitter syntax.
- [ ] The lines end with a `.`. This is to conform to `awesome-list` linting and requirements.
- [ ] The title of the pull request is ```Add/Update/Remove `username/repo` ``` (notice the backticks around ``` `username/repo` ```) when adding a new plugin.
- [ ] The description doesn't mention that it's a Neovim plugin, it's obvious from the rest of the document. No mentions of the word `plugin` unless it's related to something else. No `.. for Neovim`.
- [ ] The description doesn't contain emojis.
- [ ] Neovim is spelled as `Neovim` (not `nvim`, `NeoVim` or `neovim`), Vim is spelled as `Vim` (capitalized), Lua is spelled as `Lua` (capitalized), Tree-sitter is spelled as `Tree-sitter`.
- [ ] Acronyms should be fully capitalized, for example `LSP`, `TS`, `YAML`, etc.
