### PR TITLE
Add `neolooong/whichpy.nvim`

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,7 +232,7 @@
 - [quarto-dev/quarto-nvim](https://github.com/quarto-dev/quarto-nvim) - Tools for working with [Quarto](https://quarto.org/) documents.
 - [iabdelkareem/csharp.nvim](https://github.com/iabdelkareem/csharp.nvim) - Enhances the development experience for .NET developers.
 - [jim-at-jibba/micropython.nvim](https://github.com/jim-at-jibba/micropython.nvim) - Enhances the development experience for developers using Micro-python for IoT and maker projects.
-- [neolooong/whichpy.nvim](https://github.com/neolooong/whichpy.nvim) - Switch python interpreter inside Neovim without restarting LSP.
+- [neolooong/whichpy.nvim](https://github.com/neolooong/whichpy.nvim) - Switch Python interpreter without restarting LSP.
 
 ### Golang
 

--- a/README.md
+++ b/README.md
@@ -232,6 +232,7 @@
 - [quarto-dev/quarto-nvim](https://github.com/quarto-dev/quarto-nvim) - Tools for working with [Quarto](https://quarto.org/) documents.
 - [iabdelkareem/csharp.nvim](https://github.com/iabdelkareem/csharp.nvim) - Enhances the development experience for .NET developers.
 - [jim-at-jibba/micropython.nvim](https://github.com/jim-at-jibba/micropython.nvim) - Enhances the development experience for developers using Micro-python for IoT and maker projects.
+- [neolooong/whichpy.nvim](https://github.com/neolooong/whichpy.nvim) - Switch python interpreter inside Neovim without restarting LSP.
 
 ### Golang
 


### PR DESCRIPTION
### Repo URL:

https://github.com/neolooong/whichpy.nvim

### Checklist:

- [X] The plugin is specifically built for Neovim, or if it's a colorscheme, it supports treesitter syntax.
- [X] The lines end with a `.`. This is to conform to `awesome-list` linting and requirements.
- [X] The title of the pull request is ```Add/Update/Remove `username/repo` ``` (notice the backticks around ``` `username/repo` ```) when adding a new plugin.
- [X] The description doesn't mention that it's a Neovim plugin, it's obvious from the rest of the document. No mentions of the word `plugin` unless it's related to something else. No `.. for Neovim`.
- [X] The description doesn't contain emojis.
- [X] Neovim is spelled as `Neovim` (not `nvim`, `NeoVim` or `neovim`), Vim is spelled as `Vim` (capitalized), Lua is spelled as `Lua` (capitalized), Tree-sitter is spelled as `Tree-sitter`.
- [X] Acronyms should be fully capitalized, for example `LSP`, `TS`, `YAML`, etc.
