### PR TITLE
Add `neo451/feed.nvim`

### DIFF
--- a/README.md
+++ b/README.md
@@ -696,7 +696,7 @@ These colorschemes may not specialize in Tree-sitter directly but are written in
 - [adelarsq/image_preview.nvim](https://github.com/adelarsq/image_preview.nvim) - Image preview based on terminal's Image Protocol support.
 - [niuiic/code-shot.nvim](https://github.com/niuiic/code-shot.nvim) - Take a picture of the code.
 - [AntonVanAssche/music-controls.nvim](https://github.com/AntonVanAssche/music-controls.nvim) - Quickly control your favorite music player (Spotify, VLC, and more).
-- [neo451/feed.nvim](https://github.com/neo451/feed.nvim) - Feature-rich web feed reader, supporting rss, atom and json, all in lua
+- [neo451/feed.nvim](https://github.com/neo451/feed.nvim) - Feature-rich web feed reader, supporting rss, atom and json, all in Lua
 
 ## Note Taking
 

--- a/README.md
+++ b/README.md
@@ -696,7 +696,7 @@ These colorschemes may not specialize in Tree-sitter directly but are written in
 - [adelarsq/image_preview.nvim](https://github.com/adelarsq/image_preview.nvim) - Image preview based on terminal's Image Protocol support.
 - [niuiic/code-shot.nvim](https://github.com/niuiic/code-shot.nvim) - Take a picture of the code.
 - [AntonVanAssche/music-controls.nvim](https://github.com/AntonVanAssche/music-controls.nvim) - Quickly control your favorite music player (Spotify, VLC, and more).
-- [neo451/feed.nvim](https://github.com/neo451/feed.nvim) - Feature-rich web feed reader, supporting rss, atom and json, all in Lua
+- [neo451/feed.nvim](https://github.com/neo451/feed.nvim) - Neovim web feed reader written in Lua (RSS, atom, json feed).
 
 ## Note Taking
 

--- a/README.md
+++ b/README.md
@@ -696,6 +696,7 @@ These colorschemes may not specialize in Tree-sitter directly but are written in
 - [adelarsq/image_preview.nvim](https://github.com/adelarsq/image_preview.nvim) - Image preview based on terminal's Image Protocol support.
 - [niuiic/code-shot.nvim](https://github.com/niuiic/code-shot.nvim) - Take a picture of the code.
 - [AntonVanAssche/music-controls.nvim](https://github.com/AntonVanAssche/music-controls.nvim) - Quickly control your favorite music player (Spotify, VLC, and more).
+- [neo451/feed.nvim](https://github.com/neo451/feed.nvim) - Feature-rich web feed reader, supporting rss, atom and json, all in lua
 
 ## Note Taking
 

--- a/README.md
+++ b/README.md
@@ -696,7 +696,7 @@ These colorschemes may not specialize in Tree-sitter directly but are written in
 - [adelarsq/image_preview.nvim](https://github.com/adelarsq/image_preview.nvim) - Image preview based on terminal's Image Protocol support.
 - [niuiic/code-shot.nvim](https://github.com/niuiic/code-shot.nvim) - Take a picture of the code.
 - [AntonVanAssche/music-controls.nvim](https://github.com/AntonVanAssche/music-controls.nvim) - Quickly control your favorite music player (Spotify, VLC, and more).
-- [neo451/feed.nvim](https://github.com/neo451/feed.nvim) - Neovim web feed reader written in Lua (RSS, atom, json feed).
+- [neo451/feed.nvim](https://github.com/neo451/feed.nvim) - Web feed reader written in Lua (RSS, atom, json feed).
 
 ## Note Taking
 


### PR DESCRIPTION
### Repo URL:

https://github.com/neo451/feed.nvim

### Checklist:

- [x] The plugin is specifically built for Neovim, or if it's a colorscheme, it supports treesitter syntax.
- [x] The lines end with a `.`. This is to conform to `awesome-list` linting and requirements.
- [x] The title of the pull request is ```Add/Update/Remove `username/repo` ``` (notice the backticks around ``` `username/repo` ```) when adding a new plugin.
- [x] The description doesn't mention that it's a Neovim plugin, it's obvious from the rest of the document. No mentions of the word `plugin` unless it's related to something else. No `.. for Neovim`.
- [x] The description doesn't contain emojis.
- [x] Neovim is spelled as `Neovim` (not `nvim`, `NeoVim` or `neovim`), Vim is spelled as `Vim` (capitalized), Lua is spelled as `Lua` (capitalized), Tree-sitter is spelled as `Tree-sitter`.
- [x] Acronyms should be fully capitalized, for example `LSP`, `TS`, `YAML`, etc.
