### PR TITLE
Add `brianhuster/live-preview.nvim`

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,6 +259,7 @@
 - [cjodo/convert.nvim](https://github.com/cjodo/convert.nvim) - A tool for CSS unit conversions.
 - [farias-hecdin/CSSVarViewer](https://github.com/farias-hecdin/CSSVarViewer) - Easily visualize the content of your CSS variables in a virtual text.
 - [farias-hecdin/CSSVarHighlight](https://github.com/farias-hecdin/CSSVarHighlight) - Quickly highlight the color you defined in your CSS variables with the help of `mini.hipatterns`.
+- [brianhuster/live-preview.nvim](https://github.com/brianhuster/live-preview.nvim) - Live preview HTML, Markdown and Asciidoc in browser
 
 ### Markdown and LaTeX
 
@@ -288,6 +289,7 @@
 - [OXY2DEV/markview.nvim](https://github.com/OXY2DEV/markview.nvim) - Highly customisable markdown(latex & inline html) previewer.
 - [Kicamon/markdown-table-mode.nvim](https://github.com/Kicamon/markdown-table-mode.nvim) - Markdown format plugin like vim-table-mode but write in Lua.
 - [SCJangra/table-nvim](https://github.com/SCJangra/table-nvim) - A markdown table editor that formats the table as you type.
+- [brianhuster/live-preview.nvim](https://github.com/brianhuster/live-preview.nvim) - Live preview HTML, Markdown and Asciidoc in browser
 
 ### PHP
 


### PR DESCRIPTION
### Repo URL:
 
https://github.com/brianhuster/live-preview.nvim
### Checklist:

* [x] The plugin is specifically built for Neovim, or if it's a colorscheme, it supports treesitter syntax.

* [x] The lines end with a `.`. This is to conform to `awesome-list` linting and requirements.

* [x] The title of the pull request is `` Add/Update/Remove `username/repo`  `` (notice the backticks around `` `username/repo` ``) when adding a new plugin.

* [x]  The description doesn't mention that it's a Neovim plugin, it's obvious from the rest of the document. No mentions of the word `plugin` unless it's related to something else. No `.. for Neovim`.

* [x]  The description doesn't contain emojis.

* [x ] Neovim is spelled as `Neovim` (not `nvim`, `NeoVim` or `neovim`), Vim is spelled as `Vim` (capitalized), Lua is spelled as `Lua` (capitalized), Tree-sitter is spelled as `Tree-sitter`.

* [x]  Acronyms should be fully capitalized, for example `LSP`, `TS`, `YAML`, etc.

