### PR TITLE
Update `NvChad/colorizer-nvim.lua`

### DIFF
--- a/README.md
+++ b/README.md
@@ -521,7 +521,7 @@
 
 ## Color
 
-- [NvChad/nvim-colorizer.lua](https://github.com/NvChad/nvim-colorizer.lua) - A high-performance color highlighter which has no external dependencies!.
+- [catgoose/nvim-colorizer.lua](https://github.com/catgoose/nvim-colorizer.lua) - A high-performance color highlighter which has no external dependencies!.
 - [winston0410/range-highlight.nvim](https://github.com/winston0410/range-highlight.nvim) - An extremely lightweight plugin (~ 120loc) that highlights ranges you have entered in commandline.
 - [xiyaowong/transparent.nvim](https://github.com/xiyaowong/transparent.nvim) - Make your Neovim transparent.
 - [folke/twilight.nvim](https://github.com/folke/twilight.nvim) - Dim inactive portions of the code you're editing using Tree-sitter.

--- a/README.md
+++ b/README.md
@@ -521,7 +521,7 @@
 
 ## Color
 
-- [catgoose/nvim-colorizer.lua](https://github.com/catgoose/nvim-colorizer.lua) - A high-performance color highlighter which has no external dependencies!.
+- [catgoose/nvim-colorizer.lua](https://github.com/catgoose/nvim-colorizer.lua) - A high-performance color highlighter which has no external dependencies.
 - [winston0410/range-highlight.nvim](https://github.com/winston0410/range-highlight.nvim) - An extremely lightweight plugin (~ 120loc) that highlights ranges you have entered in commandline.
 - [xiyaowong/transparent.nvim](https://github.com/xiyaowong/transparent.nvim) - Make your Neovim transparent.
 - [folke/twilight.nvim](https://github.com/folke/twilight.nvim) - Dim inactive portions of the code you're editing using Tree-sitter.


### PR DESCRIPTION
### Repo URL:

https://github.com/catgoose/nvim-colorizer.lua

I am now maintaining `colorizer-nvim.lua`.

@siduck of NvChad invited me as maintainer:

https://github.com/catgoose/nvim-colorizer.lua/issues/88#issuecomment-2453234529

He wanted to transfer ownership of the repo to me because he didn't want any plugins in the NvChad org not written by him.  He has created his own colorizer plugin to be used for NvChad.

### Checklist:

- [ x] The plugin is specifically built for Neovim, or if it's a colorscheme, it supports treesitter syntax.
- [ x] The lines end with a `.`. This is to conform to `awesome-list` linting and requirements.
- [ x] The title of the pull request is ```Add/Update/Remove `username/repo` ``` (notice the backticks around ``` `username/repo` ```) when adding a new plugin.
- [x ] The description doesn't mention that it's a Neovim plugin, it's obvious from the rest of the document. No mentions of the word `plugin` unless it's related to something else. No `.. for Neovim`.
- [x ] The description doesn't contain emojis.
- [ x] Neovim is spelled as `Neovim` (not `nvim`, `NeoVim` or `neovim`), Vim is spelled as `Vim` (capitalized), Lua is spelled as `Lua` (capitalized), Tree-sitter is spelled as `Tree-sitter`.
- [ x] Acronyms should be fully capitalized, for example `LSP`, `TS`, `YAML`, etc.
