### PR TITLE
Add `MatanyaP/keyboard-guard.nvim`

### DIFF
--- a/README.md
+++ b/README.md
@@ -962,6 +962,7 @@ These colorschemes may not specialize in Tree-sitter directly but are written in
 - [dzfrias/arena.nvim](https://github.com/dzfrias/arena.nvim) - A smart (frecency-based) buffer switcher.
 - [MisanthropicBit/decipher.nvim](https://github.com/MisanthropicBit/decipher.nvim) - Encode and decode text using various codecs such as base64.
 - [philosofonusus/ecolog.nvim](https://github.com/philosofonusus/ecolog.nvim) - Sophisticated all-in-one toolkit to work with `.env` files and environment variables.
+- [MatanyaP/keyboard-guard.nvim](https://github.com/matandd/keyboard-guard.nvim) - Prevents unintended actions when typing in non-English keyboard layouts.
 
 ### CSV Files
 


### PR DESCRIPTION
### Repo URL:
https://github.com/MatanyaP/keyboard-guard.nvim

### About
Prevents unintended actions when typing in non-English keyboard layouts. Detects the current keyboard layout and blocks potentially destructive commands when a non-English layout is active.

Key features:
- Cross-platform support (X11, Wayland, Windows, macOS).
- Lightweight with no external dependencies for most environments.
- Configurable protection modes (normal, command, insert).
- Immediate feedback when typing with wrong layout.

### Checklist:
- [x] The plugin is specifically built for Neovim.
- [x] The lines end with a period.
- [x] The title follows the format: Add `MatanyaP/keyboard-guard.nvim`
- [x] The description doesn't mention that it's a Neovim plugin.
- [x] The description doesn't contain emojis.
- [x] Proper spelling of Neovim, Vim, Lua.
- [x] Acronyms are fully capitalized.