### PR TITLE
Add `Silletr/LazyDevHelper`

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@
 - [Note Taking](#note-taking)
 - [Utility](#utility)
   - [CSV Files](#csv-files)
-  - [LazyDevHelper](#LazyDevHelper)
+  - [LazyDevHelper](https://github.com/Silletr/LazyDevHelper)
 - [Terminal Integration](#terminal-integration)
 - [Debugging](#debugging)
   - [Quickfix](#quickfix)

--- a/README.md
+++ b/README.md
@@ -49,7 +49,8 @@
 - [Note Taking](#note-taking)
 - [Utility](#utility)
   - [CSV Files](#csv-files)
-  - [LazyDevHelper](https://github.com/Silletr/LazyDevHelper) - Install and check Python libraries directly from code using the `:SuggestImports` command. Useful when coding and managing dependencies without leaving Neovim.
+  - [LazyDevHelper](#lazydevhelper) - Install and check Python libraries directly from code using the `:SuggestImports` command. Useful when coding and managing dependencies without leaving Neovim.
+
 - [Terminal Integration](#terminal-integration)
 - [Debugging](#debugging)
   - [Quickfix](#quickfix)

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@
 - [Note Taking](#note-taking)
 - [Utility](#utility)
   - [CSV Files](#csv-files)
-  - [LazyDevHelper](https://github.com/Silletr/LazyDevHelper)
+  - [LazyDevHelper](#lazydevhelper) - Install and check Python libraries directly from code using the `:SuggestImports` command. Useful when coding and managing dependencies without leaving Neovim.
 - [Terminal Integration](#terminal-integration)
 - [Debugging](#debugging)
   - [Quickfix](#quickfix)

--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@
 - [Note Taking](#note-taking)
 - [Utility](#utility)
   - [CSV Files](#csv-files)
+  - [LazyDevHelper](https://github.com/Silletr/LazyDevHelper)
 - [Terminal Integration](#terminal-integration)
 - [Debugging](#debugging)
   - [Quickfix](#quickfix)

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@
 - [Note Taking](#note-taking)
 - [Utility](#utility)
   - [CSV Files](#csv-files)
-  - [LazyDevHelper](https://github.com/Silletr/LazyDevHelper)
+  - [LazyDevHelper](#LazyDevHelper)
 - [Terminal Integration](#terminal-integration)
 - [Debugging](#debugging)
   - [Quickfix](#quickfix)

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@
 - [Note Taking](#note-taking)
 - [Utility](#utility)
   - [CSV Files](#csv-files)
-  - [LazyDevHelper](#lazydevhelper) - Install and check Python libraries directly from code using the `:SuggestImports` command. Useful when coding and managing dependencies without leaving Neovim.
+  - [LazyDevHelper](https://github.com/Silletr/LazyDevHelper) - Install and check Python libraries directly from code using the `:SuggestImports` command. Useful when coding and managing dependencies without leaving Neovim.
 - [Terminal Integration](#terminal-integration)
 - [Debugging](#debugging)
   - [Quickfix](#quickfix)


### PR DESCRIPTION
### Repo URL:

https://github.com/Silletr/LazyDevHelper

### Checklist:

- [x] The plugin is specifically built for Neovim, or if it's a colorscheme, it supports treesitter syntax.
- [x] The lines end with a `.`. This is to conform to `awesome-list` linting and requirements.
- [x] The title of the pull request is ```Add/Update/Remove `username/repo` ``` (notice the backticks around ``` `username/repo` ```) when adding a new plugin.
- [x] The description doesn't mention that it's a Neovim plugin, it's obvious from the rest of the document. No mentions of the word `plugin` unless it's related to something else. No `.. for Neovim`.
- [x] The description doesn't contain emojis.
- [x] Neovim is spelled as `Neovim` (not `nvim`, `NeoVim` or `neovim`), Vim is spelled as `Vim` (capitalized), Lua is spelled as `Lua` (capitalized), Tree-sitter is spelled as `Tree-sitter`.
- [x] Acronyms should be fully capitalized, for example `LSP`, `TS`, `YAML`, etc.
