### PR TITLE
Add `terrastruct/d2-vim`

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@
 - [Completion](#completion)
 - [AI](#ai)
 - [Programming Languages Support](#programming-languages-support)
+  - [D2](#d2)
   - [Golang](#golang)
   - [YAML](#yaml)
   - [Web Development](#web-development)

--- a/README.md
+++ b/README.md
@@ -281,6 +281,10 @@
 - [kiyoon/haskell-scope-highlighting.nvim](https://github.com/kiyoon/haskell-scope-highlighting.nvim) - Haskell syntax highlighting that considers variable scopes. Inspired from "Context Coloring" by prof. Douglas Crockford.
 - [apyra/nvim-unity.nvim](https://github.com/apyra/nvim-unity) - Use Neovim as your default Unity editor with full LSP support via OmniSharp.
 
+### D2
+
+- [terrastruct/d2-vim](https://github.com/terrastruct/d2-vim) - Language support and syntax highlighting for D2 diagram files.
+
 ### Golang
 
 - [romus204/go-tagger.nvim](https://github.com/romus204/go-tagger.nvim) - A lightweight plugin to manage struct field tags in Go files.


### PR DESCRIPTION
Adds d2-vim plugin for D2 diagram language support to the Programming Languages Support section.

D2 is a modern diagram scripting language that turns text to diagrams. This Vim/Neovim plugin provides:
- Complete syntax highlighting with nested language support
- Auto-formatting with `d2 fmt` integration
- Validation with `d2 validate`
- D2 playground integration
- Following vim plugin best practices

Repo URL:  https://github.com/terrastruct/d2-vim  

Checklist:
- [x] The plugin is specifically built for Neovim, or if it's a colorscheme, it supports treesitter syntax.
- [x] The lines end with a .. This is to conform to awesome-list linting and requirements.
- [x] The title of the pull request is Add/Update/Remove `username/repo`  (notice the backticks around `username/repo`) when adding a new plugin.
- [x] The description doesn't mention that it's a Neovim plugin, it's obvious from the rest of the document. No mentions of the word plugin unless it's related to something else. No .. for Neovim.
- [x] The description doesn't contain emojis.
- [x] Neovim is spelled as Neovim (not nvim, NeoVim or neovim), Vim is spelled as Vim (capitalized), Lua is spelled as Lua (capitalized), Tree-sitter is spelled as Tree-sitter.
- [x] Acronyms should be fully capitalized, for example LSP, TS, YAML, etc.