### PR TITLE
add `inhesrom/remote-ssh.nvim`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1602,6 +1602,7 @@ These colorschemes may not specialize in Tree-sitter directly but are written in
 
 ## Remote Development
 
+- [inhesrom/remote-ssh.nvim](https://github.com/inhesrom/remote-ssh.nvim) - Plugin that attempts to duplicate the basic ground level functionality of VS Code's Remote SSH development plugin. Browse remote files, edit "remote buffers" with a full local editing experience (LSP, treesitter, telescope, and file watching)
 - [chipsenkbeil/distant.nvim](https://github.com/chipsenkbeil/distant.nvim) - Edit files, run programs, and work with LSP on a remote machine from the comfort of your local environment.
 - [jamestthompson3/nvim-remote-containers](https://github.com/jamestthompson3/nvim-remote-containers) - Develop inside docker containers, just like VSCode.
 - [esensar/nvim-dev-container](https://github.com/esensar/nvim-dev-container) - Neovim devcontainer.json and general development container support.

--- a/README.md
+++ b/README.md
@@ -1602,7 +1602,7 @@ These colorschemes may not specialize in Tree-sitter directly but are written in
 
 ## Remote Development
 
-- [inhesrom/remote-ssh.nvim](https://github.com/inhesrom/remote-ssh.nvim) - Plugin that attempts to duplicate the basic ground level functionality of VS Code's Remote SSH development plugin. Browse remote files, edit "remote buffers" with a full local editing experience (LSP, treesitter, telescope, and file watching)
+- [inhesrom/remote-ssh.nvim](https://github.com/inhesrom/remote-ssh.nvim) - Plugin that duplicates the basic ground level functionality of VS Code's Remote SSH development plugin. Browse remote files, edit "remote buffers" with a full local editing experience (LSP, treesitter, telescope, and file watching)
 - [chipsenkbeil/distant.nvim](https://github.com/chipsenkbeil/distant.nvim) - Edit files, run programs, and work with LSP on a remote machine from the comfort of your local environment.
 - [jamestthompson3/nvim-remote-containers](https://github.com/jamestthompson3/nvim-remote-containers) - Develop inside docker containers, just like VSCode.
 - [esensar/nvim-dev-container](https://github.com/esensar/nvim-dev-container) - Neovim devcontainer.json and general development container support.

--- a/README.md
+++ b/README.md
@@ -1602,7 +1602,7 @@ These colorschemes may not specialize in Tree-sitter directly but are written in
 
 ## Remote Development
 
-- [inhesrom/remote-ssh.nvim](https://github.com/inhesrom/remote-ssh.nvim) - Plugin that duplicates the basic ground level functionality of VS Code's Remote SSH development plugin. Browse remote files, edit "remote buffers" with a full local editing experience (LSP, treesitter, telescope, and file watching)
+- [inhesrom/remote-ssh.nvim](https://github.com/inhesrom/remote-ssh.nvim) - Plugin that duplicates the basic ground level functionality of VS Code's Remote SSH development plugin. Browse remote files, edit "remote buffers" with a full local editing experience (LSP, treesitter, telescope, and file watching).
 - [chipsenkbeil/distant.nvim](https://github.com/chipsenkbeil/distant.nvim) - Edit files, run programs, and work with LSP on a remote machine from the comfort of your local environment.
 - [jamestthompson3/nvim-remote-containers](https://github.com/jamestthompson3/nvim-remote-containers) - Develop inside docker containers, just like VSCode.
 - [esensar/nvim-dev-container](https://github.com/esensar/nvim-dev-container) - Neovim devcontainer.json and general development container support.

--- a/README.md
+++ b/README.md
@@ -1602,7 +1602,7 @@ These colorschemes may not specialize in Tree-sitter directly but are written in
 
 ## Remote Development
 
-- [inhesrom/remote-ssh.nvim](https://github.com/inhesrom/remote-ssh.nvim) - Plugin that duplicates the basic ground level functionality of VS Code's Remote SSH development plugin. Browse remote files, edit "remote buffers" with a full local editing experience (LSP, treesitter, telescope, and file watching).
+- [inhesrom/remote-ssh.nvim](https://github.com/inhesrom/remote-ssh.nvim) - Duplicates the basic ground level functionality of VSCode's Remote-SSH plugin. Browse remote files, edit "remote buffers" with a full local editing experience (LSP, Tree-sitter, Telescope integration, and a file watcher).
 - [chipsenkbeil/distant.nvim](https://github.com/chipsenkbeil/distant.nvim) - Edit files, run programs, and work with LSP on a remote machine from the comfort of your local environment.
 - [jamestthompson3/nvim-remote-containers](https://github.com/jamestthompson3/nvim-remote-containers) - Develop inside docker containers, just like VSCode.
 - [esensar/nvim-dev-container](https://github.com/esensar/nvim-dev-container) - Neovim devcontainer.json and general development container support.


### PR DESCRIPTION
### Repo URL:

https://github.com/inhesrom/remote-ssh.nvim

### Checklist:

- [x] The plugin is specifically built for Neovim, or if it's a colorscheme, it supports treesitter syntax.
- [x] The lines end with a `.`. This is to conform to `awesome-list` linting and requirements.
- [x] The title of the pull request is ```Add/Update/Remove `username/repo` ``` (notice the backticks around ``` `username/repo` ```) when adding a new plugin.
- [x] The description doesn't mention that it's a Neovim plugin, it's obvious from the rest of the document. No mentions of the word `plugin` unless it's related to something else. No `.. for Neovim`.
- [x] The description doesn't contain emojis.
- [x] Neovim is spelled as `Neovim` (not `nvim`, `NeoVim` or `neovim`), Vim is spelled as `Vim` (capitalized), Lua is spelled as `Lua` (capitalized), Tree-sitter is spelled as `Tree-sitter`.
- [x] Acronyms should be fully capitalized, for example `LSP`, `TS`, `YAML`, etc.
