### PR TITLE
Add `johannww/tts.nvim`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1068,6 +1068,7 @@ These colorschemes may not specialize in Tree-sitter directly but are written in
 - [attilarepka/header.nvim](https://github.com/attilarepka/header.nvim) - Add or update copyright and license headers in any source file.
 - [Owen-Dechow/nvim_json_graph_view](https://github.com/Owen-Dechow/nvim_json_graph_view) - Explore a JSON file as a nested unit/node-based graphical representation.
 - [toggleword.nvim](https://github.com/iquzart/toggleword.nvim) - Toggle between common code keywords under the cursor such as true ⇄ false, on ⇄ off, enabled ⇄ disabled, and dev ⇄ prod.
+- [johannww/tts.nvim](https://github.com/johannww/tts.nvim) - Text to speech tool based on the Microsoft Edge online services.
 
 ### CSV Files
 


### PR DESCRIPTION
### Repo URL:

https://github.com/johannww/tts.nvim

### Checklist:

- [X ] The plugin is specifically built for Neovim, or if it's a colorscheme, it supports treesitter syntax.
- [X ] The lines end with a `.`. This is to conform to `awesome-list` linting and requirements.
- [ X] The title of the pull request is ```Add/Update/Remove `username/repo` ``` (notice the backticks around ``` `username/repo` ```) when adding a new plugin.
- [X ] The description doesn't mention that it's a Neovim plugin, it's obvious from the rest of the document. No mentions of the word `plugin` unless it's related to something else. No `.. for Neovim`.
- [ X] The description doesn't contain emojis.
- [ X] Neovim is spelled as `Neovim` (not `nvim`, `NeoVim` or `neovim`), Vim is spelled as `Vim` (capitalized), Lua is spelled as `Lua` (capitalized), Tree-sitter is spelled as `Tree-sitter`.
- [ X] Acronyms should be fully capitalized, for example `LSP`, `TS`, `YAML`, etc.
