### PR TITLE
Add `dmtrKovalenko/fff.nvim`

### DIFF
--- a/README.md
+++ b/README.md
@@ -529,7 +529,7 @@
 - [crispgm/telescope-heading.nvim](https://github.com/crispgm/telescope-heading.nvim) - Telescope extension to switch between headings of AsciiDoc, Markdown, Vimdoc, etc.
 - [bassamsdata/namu.nvim](https://github.com/bassamsdata/namu.nvim) - Flexible and sleek fuzzy picker, LSP symbol navigator, and more. Inspired by Zed.
 - [folke/snacks.nvim#picker](https://github.com/folke/snacks.nvim/blob/main/docs/picker.md) - Modern fuzzy-finder to navigate the Neovim universe.
-- [fff.nvim](https://github.com/dmtrKovalenko/fff.nvim) - Fuzzy files picker with standalone native impelmentation of file indexing and typo resistant fuzzy matcher. Includes all the QOL features, file previews, frecency sorting, last query matching, and much more.
+- [fff.nvim](https://github.com/dmtrKovalenko/fff.nvim) - Fuzzy files picker with standalone native implementation of file indexing and typo resistant fuzzy matcher. Includes all the QOL features, file previews, frecency sorting, last query matching, and much more.
 
 <!--lint disable double-link -->
 

--- a/README.md
+++ b/README.md
@@ -529,7 +529,7 @@
 - [crispgm/telescope-heading.nvim](https://github.com/crispgm/telescope-heading.nvim) - Telescope extension to switch between headings of AsciiDoc, Markdown, Vimdoc, etc.
 - [bassamsdata/namu.nvim](https://github.com/bassamsdata/namu.nvim) - Flexible and sleek fuzzy picker, LSP symbol navigator, and more. Inspired by Zed.
 - [folke/snacks.nvim#picker](https://github.com/folke/snacks.nvim/blob/main/docs/picker.md) - Modern fuzzy-finder to navigate the Neovim universe.
-- [fff.nvim](https://github.com/dmtrKovalenko/fff.nvim) - Fuzzy files picker with standalone native implementation of file indexing and typo resistant fuzzy matcher. Includes all the QOL features, file previews, frecency sorting, last query matching, and much more.
+- [fff.nvim](https://github.com/dmtrKovalenko/fff.nvim) - Fuzzy file picker with a standalone native implementation of file indexing and typo resistant fuzzy matcher. Includes all the QOL features, file previews (and images), frecency sorting, last query matching, proximity, git status bonuses and much more.
 
 <!--lint disable double-link -->
 

--- a/README.md
+++ b/README.md
@@ -529,6 +529,7 @@
 - [crispgm/telescope-heading.nvim](https://github.com/crispgm/telescope-heading.nvim) - Telescope extension to switch between headings of AsciiDoc, Markdown, Vimdoc, etc.
 - [bassamsdata/namu.nvim](https://github.com/bassamsdata/namu.nvim) - Flexible and sleek fuzzy picker, LSP symbol navigator, and more. Inspired by Zed.
 - [folke/snacks.nvim#picker](https://github.com/folke/snacks.nvim/blob/main/docs/picker.md) - Modern fuzzy-finder to navigate the Neovim universe.
+- [fff.nvim](https://github.com/dmtrKovalenko/fff.nvim) - Fuzzy files picker with standalone native impelmentation of file indexing and typo resistant fuzzy matcher. Includes all the QOL features, file previews, frecency sorting, last query matching, and much more.
 
 <!--lint disable double-link -->
 


### PR DESCRIPTION
### Repo URL:

https://github.com/dmtrKovalenko/fff.nvim

### Checklist:

- [x] The plugin is specifically built for Neovim, or if it's a colorscheme, it supports treesitter syntax.
- [x] The lines end with a `.`. This is to conform to `awesome-list` linting and requirements.
- [x] The title of the pull request is ```Add/Update/Remove `username/repo` ``` (notice the backticks around ``` `username/repo` ```) when adding a new plugin.
- [x] The description doesn't mention that it's a Neovim plugin, it's obvious from the rest of the document. No mentions of the word `plugin` unless it's related to something else. No `.. for Neovim`.
- [x] The description doesn't contain emojis.
- [x] Neovim is spelled as `Neovim` (not `nvim`, `NeoVim` or `neovim`), Vim is spelled as `Vim` (capitalized), Lua is spelled as `Lua` (capitalized), Tree-sitter is spelled as `Tree-sitter`.
- [x] Acronyms should be fully capitalized, for example `LSP`, `TS`, `YAML`, etc.
