### PR TITLE
Update Pull Request Template checkboxes

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,10 +4,10 @@ https://github.com/...
 
 ### Checklist:
 
-- [ ] The plugin is specifically built for Neovim, or if it's a colorscheme, it supports treesitter syntax.
+- [ ] The plugin is specifically built for Neovim.
 - [ ] The lines end with a `.`. This is to conform to `awesome-list` linting and requirements.
 - [ ] The title of the pull request is ```Add/Update/Remove `username/repo` ``` (notice the backticks around ``` `username/repo` ```) when adding a new plugin.
 - [ ] The description doesn't mention that it's a Neovim plugin, it's obvious from the rest of the document. No mentions of the word `plugin` unless it's related to something else. No `.. for Neovim`.
 - [ ] The description doesn't contain emojis.
 - [ ] Neovim is spelled as `Neovim` (not `nvim`, `NeoVim` or `neovim`), Vim is spelled as `Vim` (capitalized), Lua is spelled as `Lua` (capitalized), Tree-sitter is spelled as `Tree-sitter`.
-- [ ] Acronyms should be fully capitalized, for example `LSP`, `TS`, `YAML`, etc.
+- [ ] Acronyms (`LSP`, `TS`, `YAML`, etc.) are fully capitalized.


### PR DESCRIPTION
## Description

~The first checkbox contained two different conditions,. I've split them in two for better differentiation.~
The first checkbox contained an extra condition regarding colorschemes. I agree with @Penaz91's take
in https://github.com/rockerBOO/awesome-neovim/issues/1665#issuecomment-3315939003 so I removed the second condition.

_Before:_

```markdown
- [ ] The plugin is specifically built for Neovim, or if it's a colorscheme, it supports treesitter syntax.
```

_After:_

```markdown
- [ ] The plugin is specifically built for Neovim.
```

---

## Update

I've also made the following changes:

- ~The checkbox mentioning `awesome-lint` had a typo (`awesome-list`).~
- I've reworded the checkbox regarding acronyms.