### PR TITLE
Remove `xiyaowong/nvim-cursorword`

### DIFF
--- a/README.md
+++ b/README.md
@@ -877,7 +877,6 @@ These colorschemes may not specialize in Tree-sitter directly but are written in
 ### Cursorline
 
 - [ya2s/nvim-cursorline](https://github.com/ya2s/nvim-cursorline) - A plugin that highlights cursor words and lines.
-- [xiyaowong/nvim-cursorword](https://github.com/xiyaowong/nvim-cursorword) - Part of nvim-cursorline. Highlight the word under the cursor.
 - [sontungexpt/stcursorword](https://github.com/sontungexpt/stcursorword) - Highlight the word under the cursor (Improved and compact version of nvim-cursorline).
 - [RRethy/vim-illuminate](https://github.com/RRethy/vim-illuminate) - Highlight the word under the cursor. Neovim's builtin LSP is available, it can be used to highlight more intelligently.
 - [nvim-mini/mini.nvim#mini.cursorword](https://github.com/nvim-mini/mini.nvim/blob/main/readmes/mini-cursorword.md) - Module of `mini.nvim` for automatic highlighting of word under cursor (displayed after customizable delay).


### PR DESCRIPTION
### Repo URL:

https://github.com/xiyaowong/nvim-cursorword

### Reasoning:

The repository lacks a `LICENSE` file.