### PR TITLE
Remove `sontungexpt/sttusline`

### DIFF
--- a/README.md
+++ b/README.md
@@ -858,7 +858,6 @@ These colorschemes may not specialize in Tree-sitter directly but are written in
 
 - [NTBBloodbath/galaxyline.nvim](https://github.com/NTBBloodbath/galaxyline.nvim) - A light-weight and super fast statusline plugin written in Lua.
 - [tjdevries/express_line.nvim](https://github.com/tjdevries/express_line.nvim) - Supports co-routines, functions and jobs.
-- [sontungexpt/sttusline](https://github.com/sontungexpt/sttusline) - Very lightweight, super fast and lazyloading statusline.
 - [sontungexpt/witch-line](https://github.com/sontungexpt/witch-line) - A blazing fast, lazy loading and easy to configure Neovim statusline.
 - [nvim-lualine/lualine.nvim](https://github.com/nvim-lualine/lualine.nvim) - A blazing fast and easy to configure Neovim statusline.
 - [adelarsq/neoline.vim](https://github.com/adelarsq/neoline.vim) - A light statusline/tabline plugin using Lua.


### PR DESCRIPTION
### Repo URL:

https://github.com/sontungexpt/sttusline

### Reasoning:

The owner has archived it, and [explicitly discourages its usage](https://github.com/sontungexpt/sttusline#star2important-as-i-am-currently-archived-this-plugin-please-move-to-witch-line-for-better-maintainent-and-performant).