### PR TITLE
Remove `RutaTang/quicknote.nvim`

### DIFF
--- a/README.md
+++ b/README.md
@@ -980,7 +980,6 @@ These colorschemes may not specialize in Tree-sitter directly but are written in
 - [IlyasYOY/obs.nvim](https://github.com/IlyasYOY/obs.nvim) - Your Obsidian notes at the speed of thought.
 - [jghauser/papis.nvim](https://github.com/jghauser/papis.nvim) - Manage your bibliography from within your favourite editor.
 - [Ostralyan/scribe.nvim](https://github.com/Ostralyan/scribe.nvim) - Take notes, easily.
-- [RutaTang/quicknote.nvim](https://github.com/RutaTang/quicknote.nvim) - Quickly take notes, in-place.
 - [serenevoid/kiwi.nvim](https://github.com/serenevoid/kiwi.nvim) - A stripped down VimWiki with necessary features.
 - [ada0l/obsidian/](https://github.com/ada0l/obsidian) - Base Obsidian functionality.
 - [gsuuon/note.nvim](https://github.com/gsuuon/note.nvim) - Daily tasks with deep-linking and project spaces.


### PR DESCRIPTION
### Repo URL:

https://github.com/RutaTang/quicknote.nvim

### Reasoning:

The repository lacks a `LICENSE` file.