### PR TITLE
Remove `andvarfolomeev/obsidian`

### DIFF
--- a/README.md
+++ b/README.md
@@ -981,7 +981,6 @@ These colorschemes may not specialize in Tree-sitter directly but are written in
 - [jghauser/papis.nvim](https://github.com/jghauser/papis.nvim) - Manage your bibliography from within your favourite editor.
 - [Ostralyan/scribe.nvim](https://github.com/Ostralyan/scribe.nvim) - Take notes, easily.
 - [serenevoid/kiwi.nvim](https://github.com/serenevoid/kiwi.nvim) - A stripped down VimWiki with necessary features.
-- [ada0l/obsidian/](https://github.com/ada0l/obsidian) - Base Obsidian functionality.
 - [gsuuon/note.nvim](https://github.com/gsuuon/note.nvim) - Daily tasks with deep-linking and project spaces.
 - [backdround/global-note.nvim](https://github.com/backdround/global-note.nvim) - One global note in a floating window.
 - [2KAbhishek/tdo.nvim](https://github.com/2KAbhishek/tdo.nvim) - Fast and simple note taking.


### PR DESCRIPTION
### Repo URL:

https://github.com/andvarfolomeev/obsidian

### Reasoning:

The repository lacks a `LICENSE` file.
