### PR TITLE
Remove `Cih2001/pikchr.nvim`

### DIFF
--- a/README.md
+++ b/README.md
@@ -996,7 +996,6 @@ These colorschemes may not specialize in Tree-sitter directly but are written in
 
 ## Utility
 
-- [Cih2001/pikchr.nvim](https://github.com/Cih2001/pikchr.nvim) - Render [Pikchr](https://pikchr.org/) diagrams live in Neovim.
 - [gaborvecsei/usage-tracker.nvim](https://github.com/gaborvecsei/usage-tracker.nvim) - Track your Neovim usage and visualize statistics easily.
 - [mateuszwieloch/automkdir.nvim](https://github.com/mateuszwieloch/automkdir.nvim) - Automatically create non-existent parent directories when writing a file.
 - [jghauser/mkdir.nvim](https://github.com/jghauser/mkdir.nvim) - Automatically create missing directories when saving files.


### PR DESCRIPTION
### Repo URL:

https://github.com/Cih2001/pikchr.nvim

### Reasoning:

The repository lacks a `LICENSE` file.
