### PR TITLE
Remove `gaborvecsei/cryptoprice.nvim`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1012,7 +1012,6 @@ These colorschemes may not specialize in Tree-sitter directly but are written in
 - [sQVe/bufignore.nvim](https://github.com/sQVe/bufignore.nvim) - Unlist hidden buffers matching specified ignore sources.
 - [saifulapm/commasemi.nvim](https://github.com/saifulapm/commasemi.nvim) - Toggle comma and semicolon.
 - [stevearc/dressing.nvim](https://github.com/stevearc/dressing.nvim) - Improve the built-in `vim.ui` interfaces with telescope, fzf, etc.
-- [gaborvecsei/cryptoprice.nvim](https://github.com/gaborvecsei/cryptoprice.nvim) - Check the price of the defined cryptocurrencies.
 - [jghauser/fold-cycle.nvim](https://github.com/jghauser/fold-cycle.nvim) - Cycle folds open or closed.
 - [rgroli/other.nvim](https://github.com/rgroli/other.nvim) - Open alternative files for the current buffer.
 - [toppair/reach.nvim](https://github.com/toppair/reach.nvim) - Buffer, mark, tabpage switcher.


### PR DESCRIPTION
### Repo URL:

https://github.com/gaborvecsei/cryptoprice.nvim

### Reasoning:

The repository lacks a `LICENSE` file.
