### PR TITLE
Remove `stevearc/dressing.nvim`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1011,7 +1011,6 @@ These colorschemes may not specialize in Tree-sitter directly but are written in
 - [folke/noice.nvim](https://github.com/folke/noice.nvim) - Highly experimental plugin that completely replaces the UI for messages, cmdline and the popupmenu.
 - [sQVe/bufignore.nvim](https://github.com/sQVe/bufignore.nvim) - Unlist hidden buffers matching specified ignore sources.
 - [saifulapm/commasemi.nvim](https://github.com/saifulapm/commasemi.nvim) - Toggle comma and semicolon.
-- [stevearc/dressing.nvim](https://github.com/stevearc/dressing.nvim) - Improve the built-in `vim.ui` interfaces with telescope, fzf, etc.
 - [jghauser/fold-cycle.nvim](https://github.com/jghauser/fold-cycle.nvim) - Cycle folds open or closed.
 - [rgroli/other.nvim](https://github.com/rgroli/other.nvim) - Open alternative files for the current buffer.
 - [toppair/reach.nvim](https://github.com/toppair/reach.nvim) - Buffer, mark, tabpage switcher.


### PR DESCRIPTION
### Repo URL:

https://github.com/stevearc/dressing.nvim

### Reasoning:

The plugin has been archived and the author [explicitly discourages using it](https://github.com/stevearc/dressing.nvim#dressingnvim).
