### PR TITLE
Remove `anuvyklack/fold-preview.nvim`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1024,7 +1024,6 @@ These colorschemes may not specialize in Tree-sitter directly but are written in
 - [m-demare/attempt.nvim](https://github.com/m-demare/attempt.nvim) - Manage and run temporary buffers.
 - [kevinhwang91/nvim-ufo](https://github.com/kevinhwang91/nvim-ufo) - Ultra fold with modern looking and performance boosting.
 - [sitiom/nvim-numbertoggle](https://github.com/sitiom/nvim-numbertoggle) - Neovim plugin to automatically toggle between relative and absolute line numbers.
-- [anuvyklack/fold-preview](https://github.com/anuvyklack/fold-preview.nvim) - Preview closed fold without opening it.
 - [nguyenvukhang/nvim-toggler](https://github.com/nguyenvukhang/nvim-toggler) - Invert text, such as toggling between `true` and `false`.
 - [CosmicNvim/cosmic-ui](https://github.com/CosmicNvim/cosmic-ui) - Cosmic-UI is a simple wrapper around specific Vim functionality. Built in order to provide a quick and easy way to create a Cosmic UI experience with Neovim!
 - [AckslD/messages.nvim](https://github.com/AckslD/messages.nvim) - Capture and show any messages in a customisable (floating) buffer.


### PR DESCRIPTION
### Repo URL:

https://github.com/anuvyklack/fold-preview.nvim

### Reasoning:

The repository lacks a `LICENSE` file.

---

@anuvyklack If you want this plugin to be re-added please license your plugin.

Sorry for the inconvenience!