### PR TITLE
Remove `numToStr/BufOnly.nvim`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1027,7 +1027,6 @@ These colorschemes may not specialize in Tree-sitter directly but are written in
 - [nguyenvukhang/nvim-toggler](https://github.com/nguyenvukhang/nvim-toggler) - Invert text, such as toggling between `true` and `false`.
 - [CosmicNvim/cosmic-ui](https://github.com/CosmicNvim/cosmic-ui) - Cosmic-UI is a simple wrapper around specific Vim functionality. Built in order to provide a quick and easy way to create a Cosmic UI experience with Neovim!
 - [jbyuki/instant.nvim](https://github.com/jbyuki/instant.nvim) - A collaborative editing plugin written in Lua with no dependencies.
-- [numToStr/BufOnly.nvim](https://github.com/numToStr/BufOnly.nvim) - Lua/Neovim port of BufOnly.vim with some changes.
 - [zbirenbaum/neodim](https://github.com/zbirenbaum/neodim) - Dimming the highlights of unused functions, variables, parameters, and more.
 - [bfredl/nvim-miniyank](https://github.com/bfredl/nvim-miniyank) - The killring-alike plugin with no default mappings.
 - [chrisgrieser/nvim-genghis](https://github.com/chrisgrieser/nvim-genghis) - Convenience file operations, written in Lua.


### PR DESCRIPTION
### Repo URL:

https://github.com/numToStr/BufOnly.nvim

### Reasoning:

The repository lacks a `LICENSE` file.

---

@numToStr If you want this plugin to be re-added please license your plugin.

Sorry for the inconvenience!
