### PR TITLE
Remove `GCBallesteros/NotebookNavigator.nvim`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1048,7 +1048,6 @@ These colorschemes may not specialize in Tree-sitter directly but are written in
 - [subnut/nvim-ghost.nvim](https://github.com/subnut/nvim-ghost.nvim) - GhostText support with zero dependencies.
 - [malbertzard/inline-fold.nvim](https://github.com/malbertzard/inline-fold.nvim) - Hide certain elements inline like long CSS classes or `href` content.
 - [chrisgrieser/nvim-origami](https://github.com/chrisgrieser/nvim-origami) - Fold with relentless elegance.
-- [GCBallesteros/NotebookNavigator.nvim](https://github.com/GCBallesteros/NotebookNavigator.nvim) - Navigate and execute code cells.
 - [LintaoAmons/scratch.nvim](https://github.com/LintaoAmons/scratch.nvim) - Create and manage scratch files.
 - [0xJohnnyboy/scretch.nvim](https://github.com/0xJohnnyboy/scretch.nvim) - Create and manage scratch files, scratch templates, with picker integrations.
 - [JMarkin/gentags.lua](https://github.com/JMarkin/gentags.lua) - Auto generate tag files by ctags.


### PR DESCRIPTION
### Repo URL:

https://github.com/GCBallesteros/NotebookNavigator.nvim

### Reasoning:

The repository lacks a `LICENSE` file.

---

@GCBallesteros If you want this plugin to be re-added please license your plugin.

Sorry for the inconvenience!
