### PR TITLE
Remove `GCBallesteros/jupytext.nvim`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1052,7 +1052,6 @@ These colorschemes may not specialize in Tree-sitter directly but are written in
 - [0xJohnnyboy/scretch.nvim](https://github.com/0xJohnnyboy/scretch.nvim) - Create and manage scratch files, scratch templates, with picker integrations.
 - [yutkat/confirm-quit.nvim](https://github.com/yutkat/confirm-quit.nvim) - Confirm before quitting Neovim.
 - [bgaillard/readonly.nvim](https://github.com/bgaillard/readonly.nvim) - Secure edition of files containing sensible / secret information, passwords, API keys, SSH keys, etc.
-- [GCBallesteros/jupytext.nvim](https://github.com/GCBallesteros/jupytext.nvim) - Edit jupyter notebooks without leaving Neovim.
 - [ariel-frischer/bmessages.nvim](https://github.com/ariel-frischer/bmessages.nvim) - Replace the default :messages window with a configurable, auto-updating buffer.
 - [backdround/tabscope.nvim](https://github.com/backdround/tabscope.nvim) - Make tab-local buffers.
 - [linrongbin16/gentags.nvim](https://github.com/linrongbin16/gentags.nvim) - The tags generator/management for old school vimers.


### PR DESCRIPTION
### Repo URL:

https://github.com/GCBallesteros/jupytext.nvim

### Reasoning:

The repository lacks a `LICENSE` file.

---

@GCBallesteros If you want this plugin to be re-added please license your plugin.

Sorry for the inconvenience!
