### PR TITLE
Remove `mcauley-penney/visual-whitespace.nvim`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1055,7 +1055,6 @@ These colorschemes may not specialize in Tree-sitter directly but are written in
 - [ariel-frischer/bmessages.nvim](https://github.com/ariel-frischer/bmessages.nvim) - Replace the default :messages window with a configurable, auto-updating buffer.
 - [backdround/tabscope.nvim](https://github.com/backdround/tabscope.nvim) - Make tab-local buffers.
 - [linrongbin16/gentags.nvim](https://github.com/linrongbin16/gentags.nvim) - The tags generator/management for old school vimers.
-- [mcauley-penney/visual-whitespace.nvim](https://github.com/mcauley-penney/visual-whitespace.nvim) - See whitespace characters in Visual selections, like VSCode.
 - [Zeioth/distroupdate.nvim](https://github.com/Zeioth/distroupdate.nvim) - Distro agnostic updater to get the latest changes from the Git repository of your config.
 - [SUSTech-data/neopyter](https://github.com/SUSTech-data/neopyter) - The bridge between Neovim and jupyter lab, edit in Neovim and preview/run in jupyter lab.
 - [terje/simctl.nvim](https://github.com/terje/simctl.nvim) - Interact with iOS Simulators.


### PR DESCRIPTION
### Repo URL:

https://github.com/mcauley-penney/visual-whitespace.nvim

### Reasoning:

The repository lacks a `LICENSE` file.

---

@mcauley-penney If you want this plugin to be re-added please license your plugin.

Sorry for the inconvenience!
