### PR TITLE
Remove `EL-MASTOR/bufferlist.nvim`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1068,7 +1068,6 @@ These colorschemes may not specialize in Tree-sitter directly but are written in
 - [SunnyTamang/pendulum.nvim](https://github.com/SunnyTamang/pendulum.nvim) - Simple timer for creating time based productive sessions for coders, competitive programmers, developers etc.
 - [ptdewey/pendulum-nvim](https://github.com/ptdewey/pendulum-nvim) - Track time spent coding and glean insights through on-demand time reports.
 - [rlychrisg/truncateline.nvim](https://github.com/rlychrisg/truncateline.nvim) - Truncate long lines to keep track of where you are when the start gets lost off the left side of the screen.
-- [EL-MASTOR/bufferlist.nvim](https://github.com/EL-MASTOR/bufferlist.nvim) - A super fast, lightweight, minimal and super easy buffer manager.
 - [ellisonleao/dotenv.nvim](https://github.com/ellisonleao/dotenv.nvim) - Minimalist .env support.
 - [dzfrias/arena.nvim](https://github.com/dzfrias/arena.nvim) - A smart (frecency-based) buffer switcher.
 - [MisanthropicBit/decipher.nvim](https://github.com/MisanthropicBit/decipher.nvim) - Encode and decode text using various codecs such as base64.


### PR DESCRIPTION
### Repo URL:

https://github.com/EL-MASTOR/bufferlist.nvim

### Reasoning:

The repository lacks a `LICENSE` file.

---

@EL-MASTOR If you want this plugin to be re-added please license your plugin.

Sorry for the inconvenience!
