### PR TITLE
Remove `LoricAndre/OneTerm.nvim`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1127,7 +1127,6 @@ These colorschemes may not specialize in Tree-sitter directly but are written in
 - [ingur/floatty.nvim](https://github.com/ingur/floatty.nvim) - A tiny (<200 LOC) but highly customizable floating terminal manager.
 - [imranzero/multiterm.nvim](https://github.com/imranZERO/multiterm.nvim) - Effortlessly manage multiple floating terminal windows.
 - [Dan7h3x/neaterm.nvim](https://github.com/Dan7h3x/neaterm.nvim) - A little smart terminal/REPL manager with awesome features.
-- [LoricAndre/OneTerm.nvim](https://github.com/LoricAndre/OneTerm.nvim) - Plugin framework for running commands in the terminal.
 - [nikvdp/neomux](https://github.com/nikvdp/neomux) - Control Neovim from shells running inside Neovim.
 - [willothy/flatten.nvim](https://github.com/willothy/flatten.nvim) - Open files from terminal buffers in your current Neovim instance instead of launching a nested instance.
 - [willothy/wezterm.nvim](https://github.com/willothy/wezterm.nvim) - Functions for interacting with Wezterm.


### PR DESCRIPTION
### Repo URL:

https://github.com/LoricAndre/OneTerm.nvim

### Reasoning:

The repository lacks a `LICENSE` file.

---

@LoricAndre If you want this plugin to be re-added please license your plugin.

Sorry for the inconvenience!
