### PR TITLE
Remove `willothy/wezterm.nvim`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1129,7 +1129,6 @@ These colorschemes may not specialize in Tree-sitter directly but are written in
 - [Dan7h3x/neaterm.nvim](https://github.com/Dan7h3x/neaterm.nvim) - A little smart terminal/REPL manager with awesome features.
 - [nikvdp/neomux](https://github.com/nikvdp/neomux) - Control Neovim from shells running inside Neovim.
 - [willothy/flatten.nvim](https://github.com/willothy/flatten.nvim) - Open files from terminal buffers in your current Neovim instance instead of launching a nested instance.
-- [willothy/wezterm.nvim](https://github.com/willothy/wezterm.nvim) - Functions for interacting with Wezterm.
 - [akinsho/toggleterm.nvim](https://github.com/akinsho/toggleterm.nvim) - Easily manage multiple terminal windows.
 - [norcalli/nvim-terminal.lua](https://github.com/norcalli/nvim-terminal.lua) - A high performance filetype mode which leverages conceal and highlights your buffer with the correct color codes.
 - [numToStr/FTerm.nvim](https://github.com/numToStr/FTerm.nvim) - No nonsense floating terminal written in Lua.


### PR DESCRIPTION
### Repo URL:

https://github.com/willothy/wezterm.nvim

### Reasoning:

The repository lacks a `LICENSE` file.

---

@willothy If you want this plugin to be re-added please license your plugin.

Sorry for the inconvenience!
