### PR TITLE
Remove `pianocomposer321/consolation.nvim`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1132,7 +1132,6 @@ These colorschemes may not specialize in Tree-sitter directly but are written in
 - [akinsho/toggleterm.nvim](https://github.com/akinsho/toggleterm.nvim) - Easily manage multiple terminal windows.
 - [norcalli/nvim-terminal.lua](https://github.com/norcalli/nvim-terminal.lua) - A high performance filetype mode which leverages conceal and highlights your buffer with the correct color codes.
 - [numToStr/FTerm.nvim](https://github.com/numToStr/FTerm.nvim) - No nonsense floating terminal written in Lua.
-- [pianocomposer321/consolation.nvim](https://github.com/pianocomposer321/consolation.nvim) - A general-purpose terminal wrapper and management plugin, written in Lua.
 - [jghauser/kitty-runner.nvim](https://github.com/jghauser/kitty-runner.nvim) - Poor man's REPL. Easily send buffer lines and commands to a kitty terminal.
 - [jlesquembre/nterm.nvim](https://github.com/jlesquembre/nterm.nvim) - Interact with the terminal, with notifications.
 - [s1n7ax/nvim-terminal](https://github.com/s1n7ax/nvim-terminal) - A simple & easy to use multi-terminal plugin.


### PR DESCRIPTION
### Repo URL:

https://github.com/pianocomposer321/consolation.nvim

### Reasoning:

The repository lacks a `LICENSE` file.

---

@pianocomposer321 If you want this plugin to be re-added please license your plugin.

Sorry for the inconvenience!
