### PR TITLE
Remove `m00qek/baleia.nvim`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1136,7 +1136,6 @@ These colorschemes may not specialize in Tree-sitter directly but are written in
 - [jlesquembre/nterm.nvim](https://github.com/jlesquembre/nterm.nvim) - Interact with the terminal, with notifications.
 - [s1n7ax/nvim-terminal](https://github.com/s1n7ax/nvim-terminal) - A simple & easy to use multi-terminal plugin.
 - [logicmagix/tide42](https://github.com/logicmagix/tide42) - A fully integrated terminal IDE built on Neovim, tmux, and scriptable workflows.
-- [m00qek/baleia.nvim](https://github.com/m00qek/baleia.nvim) - Colorize text with ANSI escape sequences (8, 16, 256 or TrueColor).
 - [samjwill/nvim-unception](https://github.com/samjwill/nvim-unception) - Automatic unnesting of Neovim sessions started from terminal buffers.
 - [kassio/neoterm](https://github.com/kassio/neoterm) - Wrapper of some `:terminal` functions.
 - [nyngwang/NeoTerm.lua](https://github.com/nyngwang/NeoTerm.lua) - Attach a terminal for each **buffer**, now with stable toggle and astonishing cursor restoring.


### PR DESCRIPTION
### Repo URL:

https://github.com/m00qek/baleia.nvim

### Reasoning:

The repository lacks a `LICENSE` file.

---

@m00qek If you want this plugin to be re-added please license your plugin.

Sorry for the inconvenience!
