### PR TITLE
Remove `ellisonleao/glow.nvim`

### DIFF
--- a/README.md
+++ b/README.md
@@ -346,7 +346,6 @@
 
 ### Markdown and LaTeX
 
-- [ellisonleao/glow.nvim](https://github.com/ellisonleao/glow.nvim) - Markdown preview using glow.
 - [iamcco/markdown-preview.nvim](https://github.com/iamcco/markdown-preview.nvim) - Preview Markdown on your modern browser with synchronised scrolling and flexible configuration.
 - [davidgranstrom/nvim-markdown-preview](https://github.com/davidgranstrom/nvim-markdown-preview) - Markdown preview in the browser using pandoc and live-server through Neovim's job-control API.
 - [jghauser/auto-pandoc.nvim](https://github.com/jghauser/auto-pandoc.nvim) - Easy pandoc conversion leveraging YAML blocks.


### PR DESCRIPTION
### Repo URL:

https://github.com/ellisonleao/glow.nvim

### Reasoning:

Plugin's been archived. Owner [explicitly discourages using it](https://github.com/ellisonleao/glow.nvim#project-is-now-archived).

@ellisonleao
