### PR TITLE
Remove `anott03/nvim-lspinstall`

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,7 +178,6 @@
 
 #### LSP Installer
 
-- [anott03/nvim-lspinstall](https://github.com/anott03/nvim-lspinstall) - Easy to install language servers.
 - [alexaandru/nvim-lspupdate](https://github.com/alexaandru/nvim-lspupdate) - Updates installed (or auto installs if missing) LSP servers.
 - [williamboman/mason.nvim](https://github.com/williamboman/mason.nvim) - Portable package manager that runs everywhere Neovim runs. Easily install and manage LSP servers, DAP servers, linters, and formatters.
 


### PR DESCRIPTION
### Repo URL:

https://github.com/anott03/nvim-lspinstall

### Reasoning:

The repository lacks a `LICENSE` file.

---

@anott03 If you want this plugin to be re-added please license your plugin.

Sorry for the inconvenience!
