### PR TITLE
Remove `alexaandru/nvim-lspupdate`

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,7 +178,6 @@
 
 #### LSP Installer
 
-- [alexaandru/nvim-lspupdate](https://github.com/alexaandru/nvim-lspupdate) - Updates installed (or auto installs if missing) LSP servers.
 - [williamboman/mason.nvim](https://github.com/williamboman/mason.nvim) - Portable package manager that runs everywhere Neovim runs. Easily install and manage LSP servers, DAP servers, linters, and formatters.
 
 #### Diagnostics


### PR DESCRIPTION
### Repo URL:

https://github.com/alexaandru/nvim-lspupdate

### Reasoning:

The plugin is 4 years unmaintained and [doesn't seem functional](https://github.com/alexaandru/nvim-lspupdate/issues/11).

@alexaandru
