### PR TITLE
Remove `edolphin-ydf/goimpl.nvim`

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,7 +296,6 @@
 - [ray-x/go.nvim](https://github.com/ray-x/go.nvim) - Golang plugin based on LSP and Tree-sitter.
 - [crusj/structrue-go.nvim](https://github.com/crusj/structrue-go.nvim) - A better structured display of Golang symbols information.
 - [crispgm/nvim-go](https://github.com/crispgm/nvim-go) - A minimal implementation of Golang development plugin.
-- [edolphin-ydf/goimpl.nvim](https://github.com/edolphin-ydf/goimpl.nvim) - Generate interface stubs for a type.
 - [olexsmir/gopher.nvim](https://github.com/olexsmir/gopher.nvim/) - Plugin for making Golang development easiest.
 - [rafaelsq/nvim-goc.lua](https://github.com/rafaelsq/nvim-goc.lua) - Highlight your buffer with Golang Code Coverage.
 - [crusj/hierarchy-tree-go.nvim](https://github.com/crusj/hierarchy-tree-go.nvim) - Neovim plugin for Golang, callHierarchy UI tree.


### PR DESCRIPTION
### Repo URL:

https://github.com/edolphin-ydf/goimpl.nvim

### Reasoning:

The repository lacks a `LICENSE` file.

---

@edolphin-ydf If you want this plugin to be re-added please license your plugin.

Sorry for the inconvenience!
