### PR TITLE
Remove `AckslD/nvim-FeMaco.lua`

### DIFF
--- a/README.md
+++ b/README.md
@@ -336,7 +336,6 @@
 - [kdheepak/panvimdoc](https://github.com/kdheepak/panvimdoc) - A pandoc to vimdoc GitHub action.
 - [frabjous/knap](https://github.com/frabjous/knap) - Plugin for creating automatic updating-as-you-type previews for Markdown, LaTeX and other documents.
 - [jbyuki/carrot.nvim](https://github.com/jbyuki/carrot.nvim) - Markdown evaluator Lua code blocks.
-- [AckslD/nvim-FeMaco.lua](https://github.com/AckslD/nvim-FeMaco.lua) - Catalyze your Fenced Markdown Code-block editing.
 - [Nedra1998/nvim-mdlink](https://github.com/Nedra1998/nvim-mdlink) - Simplify creating and following Markdown links.
 - [nfrid/markdown-togglecheck](https://github.com/nfrid/markdown-togglecheck) - Simple Neovim plugin for toggling check boxes using Tree-sitter.
 - [toppair/peek.nvim](https://github.com/toppair/peek.nvim) - Preview Markdown in a webview window.


### PR DESCRIPTION
### Repo URL:

https://github.com/AckslD/nvim-FeMaco.lua

### Reasoning:

The repository lacks a `LICENSE` file.

---

@AckslD If you want this plugin to be re-added please license your plugin.

Sorry for the inconvenience!
