### PR TITLE
Remove `gbprod/phpactor.nvim`

### DIFF
--- a/README.md
+++ b/README.md
@@ -358,7 +358,6 @@
 
 ### PHP
 
-- [gbprod/phpactor.nvim](https://github.com/gbprod/phpactor.nvim) - Lua version of the Phpactor Vim plugin to take advantage of the latest Neovim features.
 - [ta-tikoma/php.easy.nvim](https://github.com/ta-tikoma/php.easy.nvim) - Methods of assistance in PHP development: create classes, constants, methods, properties; simple copying and deleting of an entity.
 
 <!--lint disable double-link -->


### PR DESCRIPTION
### Repo URL:

https://github.com/gbprod/phpactor.nvim

### Reasoning:

The repository lacks a `LICENSE` file.

---

@gbprod If you want this plugin to be re-added please license your plugin.

Sorry for the inconvenience!
