### PR TITLE
Remove `kiyoon/Korean-IME.nvim`

### DIFF
--- a/README.md
+++ b/README.md
@@ -392,7 +392,6 @@
 - [niuiic/translate.nvim](https://github.com/niuiic/translate.nvim) - Invoke any translation engine via shell command.
 - [tanloong/interlaced.nvim](https://github.com/tanloong/interlaced.nvim) - Help align bilingual parallel texts.
 - [sontungexpt/vietnamese.nvim](https://github.com/sontungexpt/vietnamese.nvim) - A Vietnamese input method engine with native support to type Vietnamese in insert mode.
-- [kiyoon/Korean-IME.nvim](https://github.com/kiyoon/Korean-IME.nvim) - OS-independent Korean input method that converts English inputs to Korean in-place.
 - [doodleEsc/translator.nvim](https://github.com/doodleEsc/translator.nvim) - A powerful AI-powered translation plugin, leveraging OpenAI's GPT models to provide high-quality translations with natural language understanding.
 
 <!--lint disable double-link -->


### PR DESCRIPTION
### Repo URL:

https://github.com/kiyoon/Korean-IME.nvim

### Reasoning:

The repository lacks a `LICENSE` file.

---

@kiyoon If you want this plugin to be re-added please license your plugin.

Sorry for the inconvenience!
