### PR TITLE
Add `salorak/libtmux.nvim`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1693,7 +1693,7 @@ These colorschemes may not specialize in Tree-sitter directly but are written in
 - [juselara1/tmutils.nvim](https://github.com/juselara1/tmutils.nvim) - Tmux utilities that enable sending lines, capturing content, creating terminals, and managing REPLs.
 - [kiyoon/tmux-send.nvim](https://github.com/kiyoon/tmux-send.nvim) - Copy and paste buffer content or file path in Nvim-Tree, Neo-Tree, Oil to another tmux pane in Neovim.
 - [jkeresman01/tmux-switch.nvim](https://github.com/jkeresman01/tmux-switch.nvim) - Provides fuzzy session switching for Tmux.
-- [salorak/libtmux.nvim](https://github.com/salorak/libtmux.nvim) - Thin wrapper to use all Tmux API directly.
+- [salorak/libtmux.nvim](https://github.com/salorak/libtmux.nvim) - Thin wrapper for using the `tmux` API.
 
 <!--lint disable double-link -->
 


### PR DESCRIPTION
### Repo URL:

https://github.com/salorak/libtmux.nvim

### Checklist:

- [X] The plugin is specifically built for Neovim.
- [X] The plugin is licensed.
- [X] The lines end with a `.`. This is to conform to `awesome-list` linting and requirements.
- [X] The title of the pull request is ```Add/Update/Remove `username/repo` ``` (notice the backticks around ``` `username/repo` ```) when adding a new plugin.
- [X] The description doesn't mention that it's a Neovim plugin, it's obvious from the rest of the document. No mentions of the word `plugin` unless it's related to something else. No `.. for Neovim`.
- [X] The description doesn't contain emojis.
- [X] Neovim is spelled as `Neovim` (not `nvim`, `NeoVim` or `neovim`), Vim is spelled as `Vim` (capitalized), Lua is spelled as `Lua` (capitalized), Tree-sitter is spelled as `Tree-sitter`.
- [X] Acronyms (`LSP`, `TS`, `YAML`, etc.) are fully capitalized.
