### PR TITLE
Remove `DrKJeff16/lastplace.nvim`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1071,7 +1071,6 @@ These colorschemes may not specialize in Tree-sitter directly but are written in
 - [johannww/tts.nvim](https://github.com/johannww/tts.nvim) - Text to speech tool based on the Microsoft Edge online services.
 - [doctorfree/cheatsheet.nvim](https://github.com/doctorfree/cheatsheet.nvim) - Searchable cheatsheet.
 - [gaborvecsei/cryptoprice.nvim](https://github.com/gaborvecsei/cryptoprice.nvim) - Check the price of the defined cryptocurrencies.
-- [DrKJeff16/lastplace.nvim](https://github.com/DrKJeff16/lastplace.nvim) - An up-to-date rewrite of [ethanholz/nvim-lastplace](https://github.com/ethanholz/nvim-lastplace) for opening a file in the last edit position.
 
 ### CSV Files
 


### PR DESCRIPTION
### Repo URL:

https://github.com/DrKJeff16/lastplace.nvim

### Reasoning:

I've archived this plugin in favour of [`nxhung2304/lastplace.nvim`](https://github.com/nxhung2304/lastplace.nvim), which looks like a better alternative. A PR for that plugin will be opened in a sec.