### PR TITLE
Remove `RutaTang/spectacle.nvim`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1642,7 +1642,6 @@ These colorschemes may not specialize in Tree-sitter directly but are written in
 - [Shatur/neovim-session-manager](https://github.com/Shatur/neovim-session-manager) - A simple wrapper around :mksession.
 - [jedrzejboczar/possession.nvim](https://github.com/jedrzejboczar/possession.nvim) - Flexible session management with arbitrary persistent data stored as JSON.
 - [niuiic/multiple-session.nvim](https://github.com/niuiic/multiple-session.nvim) - Provides multi-session management capabilities.
-- [RutaTang/spectacle.nvim](https://github.com/RutaTang/spectacle.nvim) - Easily manage multiple sessions with telescope integration.
 - [coffebar/neovim-project](https://github.com/coffebar/neovim-project) - Declarative project management, automatic saving of sessions, uses Telescope.
 - [njayman/season.nvim](https://github.com/njayman/season.nvim) - A lightweight plugin to manage session based on current working directory.
 


### PR DESCRIPTION
### Repo URL:

https://github.com/RutaTang/spectacle.nvim

### Reasoning:

The repository lacks a `LICENSE` file.

---

@RutaTang If you want this plugin to be re-added please license your plugin.

Sorry for the inconvenience!
