### PR TITLE
Remove `gpanders/editorconfig.nvim`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1581,7 +1581,6 @@ These colorschemes may not specialize in Tree-sitter directly but are written in
 ## Formatting
 
 - [TheLazyCat00/simple-format](https://github.com/TheLazyCat00/simple-format) - Replace text using custom regex and highlight group rules.
-- [gpanders/editorconfig.nvim](https://github.com/gpanders/editorconfig.nvim) - An EditorConfig plugin written in Fennel.
 - [mhartington/formatter.nvim](https://github.com/mhartington/formatter.nvim) - A format runner written in Lua.
 - [lukas-reineke/lsp-format.nvim](https://github.com/lukas-reineke/lsp-format.nvim) - A wrapper around Neovim's native LSP formatting.
 - [sbdchd/neoformat](https://github.com/sbdchd/neoformat) - A (Neo)vim plugin for formatting code.


### PR DESCRIPTION
### Repo URL:

https://github.com/gpanders/editorconfig.nvim

### Reasoning:

Plugin has been archived. [Author states it's outdated](https://github.com/gpanders/editorconfig.nvim).

@gpanders