### PR TITLE
Remove `lukas-reineke/lsp-format.nvim`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1583,7 +1583,6 @@ These colorschemes may not specialize in Tree-sitter directly but are written in
 - [TheLazyCat00/simple-format](https://github.com/TheLazyCat00/simple-format) - Replace text using custom regex and highlight group rules.
 - [gpanders/editorconfig.nvim](https://github.com/gpanders/editorconfig.nvim) - An EditorConfig plugin written in Fennel.
 - [mhartington/formatter.nvim](https://github.com/mhartington/formatter.nvim) - A format runner written in Lua.
-- [lukas-reineke/lsp-format.nvim](https://github.com/lukas-reineke/lsp-format.nvim) - A wrapper around Neovim's native LSP formatting.
 - [sbdchd/neoformat](https://github.com/sbdchd/neoformat) - A (Neo)vim plugin for formatting code.
 - [cappyzawa/trim.nvim](https://github.com/cappyzawa/trim.nvim) - Trims trailing whitespace and lines.
 - [mcauley-penney/tidy.nvim](https://github.com/mcauley-penney/tidy.nvim) - Clear trailing whitespace and empty lines at end of file on every save.


### PR DESCRIPTION
### Repo URL:

https://github.com/lukas-reineke/lsp-format.nvim

### Reasoning:

The repository lacks a `LICENSE` file.

---

@lukas-reineke If you want this plugin to be re-added please license your plugin.

Sorry for the inconvenience!
