### PR TITLE
Remove `mcauley-penney/tidy.nvim`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1585,7 +1585,6 @@ These colorschemes may not specialize in Tree-sitter directly but are written in
 - [mhartington/formatter.nvim](https://github.com/mhartington/formatter.nvim) - A format runner written in Lua.
 - [sbdchd/neoformat](https://github.com/sbdchd/neoformat) - A (Neo)vim plugin for formatting code.
 - [cappyzawa/trim.nvim](https://github.com/cappyzawa/trim.nvim) - Trims trailing whitespace and lines.
-- [mcauley-penney/tidy.nvim](https://github.com/mcauley-penney/tidy.nvim) - Clear trailing whitespace and empty lines at end of file on every save.
 - [MunifTanjim/prettier.nvim](https://github.com/MunifTanjim/prettier.nvim) - Prettier integration.
 - [nvim-mini/mini.nvim#mini.align](https://github.com/nvim-mini/mini.nvim/blob/main/readmes/mini-align.md) - Module of `mini.nvim` for aligning text interactively (with or without instant preview).
 - [emileferreira/nvim-strict](https://github.com/emileferreira/nvim-strict) - Strict, native code style formatting which exposes deep nesting, overlong lines, trailing whitespace, trailing empty lines, todos and inconsistent indentation.


### PR DESCRIPTION
### Repo URL:

https://github.com/mcauley-penney/tidy.nvim

### Reasoning:

The repository lacks a `LICENSE` file.

---

@mcauley-penney If you want this plugin to be re-added please license your plugin.

Sorry for the inconvenience!
