### PR TITLE
Remove `xiyaowong/transparent.nvim`

### DIFF
--- a/README.md
+++ b/README.md
@@ -606,7 +606,6 @@
 
 - [catgoose/nvim-colorizer.lua](https://github.com/catgoose/nvim-colorizer.lua) - A high-performance color highlighter which has no external dependencies.
 - [winston0410/range-highlight.nvim](https://github.com/winston0410/range-highlight.nvim) - An extremely lightweight plugin (~ 120loc) that highlights ranges you have entered in commandline.
-- [xiyaowong/transparent.nvim](https://github.com/xiyaowong/transparent.nvim) - Make your Neovim transparent.
 - [folke/twilight.nvim](https://github.com/folke/twilight.nvim) - Dim inactive portions of the code you're editing using Tree-sitter.
 - [koenverburg/peepsight.nvim](https://github.com/koenverburg/peepsight.nvim) - Focus only the function your cursor is in.
 - [uga-rosa/ccc.nvim](https://github.com/uga-rosa/ccc.nvim) - Super powerful color picker / colorizer plugin.


### PR DESCRIPTION
### Repo URL:

https://github.com/xiyaowong/transparent.nvim

### Reasoning:

The repository lacks a `LICENSE` file.

---

@xiyaowong If you want this plugin to be re-added please license your plugin.

Sorry for the inconvenience!
