### PR TITLE
Remove `norcalli/snippets.nvim`

### DIFF
--- a/README.md
+++ b/README.md
@@ -429,7 +429,6 @@
 
 ## Snippet
 
-- [norcalli/snippets.nvim](https://github.com/norcalli/snippets.nvim) - Snippets in Lua.
 - [L3MON4D3/LuaSnip](https://github.com/L3MON4D3/LuaSnip) - A snippet engine written in Lua.
 - [nvim-mini/mini.nvim#mini.snippets](https://github.com/nvim-mini/mini.nvim/blob/main/readmes/mini-snippets.md) - Module of `mini.nvim` to manage and expand snippets. Supports LSP snippet syntax, flexible loaders, fuzzy prefix matching, interactive selection, snippet session with rich visualization, and more.
 - [smjonas/snippet-converter.nvim](https://github.com/smjonas/snippet-converter.nvim) - Convert snippets between the most common snippet formats and modify them using a few lines of Lua code.


### PR DESCRIPTION
### Repo URL:

https://github.com/norcalli/snippets.nvim

### Reasoning:

5 years unmaintained, further maintenance seems unlikely, [issues with functionality](https://github.com/norcalli/snippets.nvim/issues).

@norcalli
