### PR TITLE
Remove `cxwx/specs.nvim`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1087,7 +1087,6 @@ These colorschemes may not specialize in Tree-sitter directly but are written in
 - [rachartier/tiny-glimmer.nvim](https://github.com/rachartier/tiny-glimmer.nvim/) - Adds subtle animations to various operations.
 - [y3owk1n/undo-glow.nvim](https://github.com/y3owk1n/undo-glow.nvim/) - Animated glow/highlight effects for Neovim operations (undo, redo, yank, paste, etc.) with fully customizable animations and appearance.
 - [gen740/SmoothCursor.nvim](https://github.com/gen740/SmoothCursor.nvim) - Add fancy sub-cursor to signcolumn to show your scroll or jump direction.
-- [cxwx/specs.nvim](https://github.com/cxwx/specs.nvim) - A fast and lightweight Neovim Lua plugin to keep an eye on where your cursor has jumped.
 
 <!--lint disable double-link -->
 


### PR DESCRIPTION
### Repo URL:

https://github.com/cxwx/specs.nvim

### Reasoning:

The repository lacks a `LICENSE` file.

---

@cxwx If you want this plugin to be re-added please license your plugin.

Sorry for the inconvenience!
