### PR TITLE
Remove `coffebar/transfer.nvim`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1165,7 +1165,6 @@ These colorschemes may not specialize in Tree-sitter directly but are written in
 
 ## Deployment
 
-- [coffebar/transfer.nvim](https://github.com/coffebar/transfer.nvim) - Sync and diff with remote server using rsync and OpenSSH.
 - [OscarCreator/rsync.nvim](https://github.com/OscarCreator/rsync.nvim) - Automatically sync up/down project to a remote with rsync.
 - [sachinsenal0x64/hot.nvim](https://github.com/sachinsenal0x64/hot.nvim) - A hot reloader that works with any programming language.
 


### PR DESCRIPTION
### Repo URL:

https://github.com/coffebar/transfer.nvim

### Reasoning:

The repository lacks a `LICENSE` file.

---

@coffebar If you want this plugin to be re-added please license your plugin.

Sorry for the inconvenience!
