### PR TITLE
Remove `akinsho/git-conflict.nvim`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1309,7 +1309,6 @@ These colorschemes may not specialize in Tree-sitter directly but are written in
 - [sindrets/diffview.nvim](https://github.com/sindrets/diffview.nvim) - Single tabpage interface for easily cycling through diffs for all modified files for any Git rev.
 - [kdheepak/lazygit.nvim](https://github.com/kdheepak/lazygit.nvim) - Plugin for calling lazygit.
 - [AckslD/nvim-gfold.lua](https://github.com/AckslD/nvim-gfold.lua) - Plugin using [gfold](https://github.com/nickgerace/gfold) to switch repo and have statusline component.
-- [akinsho/git-conflict.nvim](https://github.com/akinsho/git-conflict.nvim) - A plugin to visualise and resolve merge conflicts.
 - [aaronhallaert/advanced-git-search.nvim](https://github.com/aaronhallaert/advanced-git-search.nvim) - Search your Git history by commit content, message and author with Telescope.
 - [9seconds/repolink.nvim](https://github.com/9seconds/repolink.nvim) - Generate shareable HTTP permalinks for various Git web frontends.
 - [chrisgrieser/nvim-tinygit](https://github.com/chrisgrieser/nvim-tinygit) - Lightweight and nimble Git client.


### PR DESCRIPTION
### Repo URL:

https://github.com/akinsho/git-conflict.nvim

### Reasoning:

The repository lacks a `LICENSE` file.

---

@akinsho If you want this plugin to be re-added please license your plugin.

Sorry for the inconvenience!
