### PR TITLE
Remove `bfredl/nvim-ipy`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1214,7 +1214,6 @@ These colorschemes may not specialize in Tree-sitter directly but are written in
 - [jaytyrrell13/static.nvim](https://github.com/jaytyrrell13/static.nvim) - Run static site generator commands.
 - [dasupradyumna/launch.nvim](https://github.com/dasupradyumna/launch.nvim) - A simple and quick task launcher which allows dynamically configuring tasks on the fly, with optional support for debugging.
 - [benlubas/molten-nvim](https://github.com/benlubas/molten-nvim) - Enables running code chunks via the jupyter kernel. Output (including image output) is rendered in a floating window below the code.
-- [bfredl/nvim-ipy](https://github.com/bfredl/nvim-ipy) - Make interfacing with IPython/Jupyter easier.
 - [pianocomposer321/officer.nvim](https://github.com/pianocomposer321/officer.nvim) - Like dispatch.vim but using overseer.nvim.
 - [speelbarrow/spLauncher.nvim](https://github.com/speelbarrow/spLauncher.nvim) - For launching tasks, I guess.
 - [al1-ce/just.nvim](https://github.com/al1-ce/just.nvim) - Task runner for justfiles.


### PR DESCRIPTION
### Repo URL:

https://github.com/bfredl/nvim-ipy

### Reasoning:

Unmaintained for 4 years, [likely not functional](https://github.com/bfredl/nvim-ipy/issues).

@bfredl
