### PR TITLE
Remove `pwntester/codeql.nvim`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1330,7 +1330,6 @@ These colorschemes may not specialize in Tree-sitter directly but are written in
 ### GitHub
 
 - [pwntester/octo.nvim](https://github.com/pwntester/octo.nvim) - Work with GitHub issues and PRs from Neovim. Just edit the issue description.
-- [pwntester/codeql.nvim](https://github.com/pwntester/codeql.nvim) - Neovim plugin to help writing and testing CodeQL queries.
 - [ldelossa/gh.nvim](https://github.com/ldelossa/gh.nvim) - A fully featured GitHub integration for performing code reviews.
 - [topaxi/pipeline.nvim](https://github.com/topaxi/pipeline.nvim) - View and dispatch GitHub Actions workflow and GitLab CI pipeline runs.
 - [rawnly/gist.nvim](https://github.com/rawnly/gist.nvim) - Create a GitHub Gist from the current file (powered by gh).


### PR DESCRIPTION
### Repo URL:

https://github.com/pwntester/codeql.nvim

### Reasoning:

The repository lacks a `LICENSE` file.

---

@pwntester If you want this plugin to be re-added please license your plugin.

Sorry for the inconvenience!
