### PR TITLE
Remove `claydugo/browsher.nvim`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1334,7 +1334,6 @@ These colorschemes may not specialize in Tree-sitter directly but are written in
 - [topaxi/pipeline.nvim](https://github.com/topaxi/pipeline.nvim) - View and dispatch GitHub Actions workflow and GitLab CI pipeline runs.
 - [rawnly/gist.nvim](https://github.com/rawnly/gist.nvim) - Create a GitHub Gist from the current file (powered by gh).
 - [2KAbhishek/octohub.nvim](https://github.com/2KAbhishek/octohub.nvim) - Access all your gihub repos, stats and more in simple keystrokes.
-- [claydugo/browsher.nvim](https://github.com/claydugo/browsher.nvim) - Create commit pinned links to GitHub hosted files/lines. Avoid stale links.
 - [comatory/gh-co.nvim](https://github.com/comatory/gh-co.nvim) - Show the code owner(s) for files according to GitHub's `CODEOWNERS` specification.
 - [3ZsForInsomnia/revman.nvim](https://github.com/3ZsForInsomnia/revman.nvim) - Track PRs that need review automatically and open them in Octo.nvim.
 - [cd-4/git-needy.nvim](https://github.com/cd-4/git-needy.nvim) - Keeps a tally of workflows that need to be reviewed in your statusbar.


### PR DESCRIPTION
### Repo URL:

https://github.com/claydugo/browsher.nvim

### Reasoning:

The repository lacks a `LICENSE` file.

---

@claydugo If you want this plugin to be re-added please license your plugin.

Sorry for the inconvenience!
