### PR TITLE
Remove `Weissle/easy-action`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1365,7 +1365,6 @@ These colorschemes may not specialize in Tree-sitter directly but are written in
 - [xiaoshihou514/squirrel.nvim](https://github.com/xiaoshihou514/squirrel.nvim) - Quickly jump between Tree-sitter nodes.
 - [abecodes/tabout.nvim](https://github.com/abecodes/tabout.nvim) - Jump out of brackets, quotes, objects, etc.
 - [woosaaahh/sj.nvim](https://github.com/woosaaahh/sj.nvim) - Search based navigation combined with quick jump features.
-- [Weissle/easy-action](https://github.com/Weissle/easy-action) - Easily perform an action on where you can see.
 - [cbochs/portal.nvim](https://github.com/cbochs/portal.nvim) - Build upon and enhance existing jumplist motions (i.e. `<c-i>` and `<c-o>`).
 - [nvim-mini/mini.nvim#mini.bracketed](https://github.com/nvim-mini/mini.nvim/blob/main/readmes/mini-bracketed.md) - Module of `mini.nvim` to go forward/backward with square brackets.
 - [liangxianzhe/nap.nvim](https://github.com/liangxianzhe/nap.nvim) - Jump between next/previous buffer, tab, diagnostic, etc, with a single key.


### PR DESCRIPTION
### Repo URL:

https://github.com/Weissle/easy-action

### Reasoning:

The repository lacks a `LICENSE` file.

---

@Weissle If you want this plugin to be re-added please license your plugin.

Sorry for the inconvenience!
