### PR TITLE
Remove `DanilaMihailov/beacon.nvim`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1372,7 +1372,6 @@ These colorschemes may not specialize in Tree-sitter directly but are written in
 - [backdround/neowords.nvim](https://github.com/backdround/neowords.nvim) - Hops by any type of words. It gives fine control over `w`, `e`, `b`, `ge` movements.
 - [backdround/improved-ft.nvim](https://github.com/backdround/improved-ft.nvim) - Improve default `f`/`t` abilities.
 - [Mr-LLLLL/treesitter-outer](https://github.com/Mr-LLLLL/treesitter-outer) - Jump to outer node with smart.
-- [DanilaMihailov/beacon.nvim](https://github.com/DanilaMihailov/beacon.nvim) - Highlights cursor when it moves, changes windows and more. Inspired by Emacs beacon package.
 - [Aaronik/Treewalker.nvim](https://github.com/aaronik/Treewalker.nvim) - Move seamlessly around the abstract syntax tree.
 - [timseriakov/spamguard.nvim](https://github.com/timseriakov/spamguard.nvim) - Detects excessive key spamming (jjjj/kkkk) and suggests more efficient alternatives.
 - [millerjason/neovimacs.nvim](https://github.com/millerjason/neovimacs.nvim) - Provides emacs movement and buffer keybindings while in insert mode.


### PR DESCRIPTION
### Repo URL:

https://github.com/DanilaMihailov/beacon.nvim

### Reasoning:

The repository lacks a `LICENSE` file.

---

@DanilaMihailov If you want this plugin to be re-added please license your plugin.

Sorry for the inconvenience!
