### PR TITLE
Remove `ziontee113/syntax-tree-surfer`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1379,7 +1379,6 @@ These colorschemes may not specialize in Tree-sitter directly but are written in
 ### Tree-sitter Based
 
 - [mfussenegger/nvim-treehopper](https://github.com/mfussenegger/nvim-treehopper) - Region selection with hints on the AST nodes of a document powered by Tree-sitter.
-- [ziontee113/syntax-tree-surfer](https://github.com/ziontee113/syntax-tree-surfer) - Navigate and swap Tree-sitter's AST Nodes. Step into, step out, step over, step back.
 - [drybalka/tree-climber.nvim](https://github.com/drybalka/tree-climber.nvim) - Easy navigation around the Tree-sitter's tree that works in multi-language files and in normal mode.
 - [atusy/treemonkey.nvim](https://github.com/atusy/treemonkey.nvim) - Region selection with Tree-sitter nodes.
 - [kiyoon/treesitter-indent-object.nvim](https://github.com/kiyoon/treesitter-indent-object.nvim) - Context-aware indent textobject powered by Tree-sitter.


### PR DESCRIPTION
### Repo URL:

https://github.com/ziontee113/syntax-tree-surfer

### Reasoning:

Plugin has been archived for a year, no active forks. Author seems inactive.
