### PR TITLE
Remove `nkakouros-original/scrollofffraction.nvim`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1429,7 +1429,6 @@ These colorschemes may not specialize in Tree-sitter directly but are written in
 - [Saghen/filler-begone.nvim](https://github.com/Saghen/filler-begone.nvim) - Prevents scrolling past the bottom of the buffer and showing unnecessary filler lines.
 - [karb94/neoscroll.nvim](https://github.com/karb94/neoscroll.nvim) - Smooth scrolling.
 - [declancm/cinnamon.nvim](https://github.com/declancm/cinnamon.nvim) - Smooth scrolling for any movement command.
-- [nkakouros-original/scrollofffraction.nvim](https://github.com/nkakouros-original/scrollofffraction.nvim) - Scrolloff as a fraction of the window height.
 - [niuiic/scroll.nvim](https://github.com/niuiic/scroll.nvim) - Smooth scrolling, custom smooth strategy.
 - [rlychrisg/keepcursor.nvim](https://github.com/rlychrisg/keepcursor.nvim) - A collection of functions to control how the screen is positioned around the cursor.
 


### PR DESCRIPTION
### Repo URL:

https://github.com/nkakouros-original/scrollofffraction.nvim

### Reasoning:

The repository lacks a `LICENSE` file.

---

@nkakouros-original If you want this plugin to be re-added please license your plugin.

Sorry for the inconvenience!
