### PR TITLE
Remove `johmsalas/text-case.nvim`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1485,7 +1485,6 @@ These colorschemes may not specialize in Tree-sitter directly but are written in
 - [gbprod/cutlass.nvim](https://github.com/gbprod/cutlass.nvim) - Plugin that adds a 'cut' operation separate from 'delete'.
 - [gbprod/substitute.nvim](https://github.com/gbprod/substitute.nvim) - Neovim plugin introducing a new operator motions to quickly replace and exchange text.
 - [gregorias/coerce.nvim](https://github.com/gregorias/coerce.nvim) - Change keyword case.
-- [johmsalas/text-case.nvim](https://github.com/johmsalas/text-case.nvim) - Text case changes via keybindings and custom substitute command with Telescope and LSP support.
 - [nvim-mini/mini.nvim#mini.operators](https://github.com/nvim-mini/mini.nvim/blob/main/readmes/mini-operators.md) - Module of `mini.nvim` with various text edit operators: replace, exchange, multiply, sort, evaluate.
 - [gbprod/yanky.nvim](https://github.com/gbprod/yanky.nvim) - Improved Yank and Put functionalities.
 - [sQVe/sort.nvim](https://github.com/sQVe/sort.nvim) - Sorting plugin that intelligently supports line-wise and delimiter sorting.


### PR DESCRIPTION
### Repo URL:

https://github.com/johmsalas/text-case.nvim

### Reasoning:

The repository lacks a `LICENSE` file.

---

@johmsalas If you want this plugin to be re-added please license your plugin.

Sorry for the inconvenience!
