### PR TITLE
Add `TheItcor/MoaiVim`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1775,7 +1775,7 @@ These colorschemes may not specialize in Tree-sitter directly but are written in
 - [ayamir/nvimdots](https://github.com/ayamir/nvimdots) - A well-configured and structured configuration with NixOS support.
 - [adoyle-h/one.nvim](https://github.com/adoyle-h/one.nvim) - All-in-one config framework in Lua.
 - [nvim-mini/MiniMax](https://github.com/nvim-mini/MiniMax) - A collection of self-contained and extensively commented configurations which mostly use MINI tools.
-- [TheItcor/MoaiVim](https://github.com/TheItcor/MoaiVim) - A minimalist, fast Neovim config that feels like an IDE but stays lightweight. Programming without the bloat.
+- [TheItcor/MoaiVim](https://github.com/TheItcor/MoaiVim) - A minimalist config that emulates a lightweight IDE.
 
 <!--lint disable double-link -->
 


### PR DESCRIPTION
### Repo URL:

https://github.com/TheItcor/MoaiVim

### Checklist:

- [x] The plugin is specifically built for Neovim.
- [x] The plugin is licensed.
- [x] The lines end with a `.`. This is to conform to `awesome-list` linting and requirements.
- [x] The title of the pull request is ```Add/Update/Remove `username/repo` ``` (notice the backticks around ``` `username/repo` ```) when adding a new plugin.
- [x] The description doesn't mention that it's a Neovim plugin, it's obvious from the rest of the document. No mentions of the word `plugin` unless it's related to something else. No `.. for Neovim`.
- [x] The description doesn't contain emojis.
- [x] Neovim is spelled as `Neovim` (not `nvim`, `NeoVim` or `neovim`), Vim is spelled as `Vim` (capitalized), Lua is spelled as `Lua` (capitalized), Tree-sitter is spelled as `Tree-sitter`.
- [x] Acronyms (`LSP`, `TS`, `YAML`, etc.) are fully capitalized.
