### PR TITLE
Remove `kyazdani42/blue-moon`

### DIFF
--- a/README.md
+++ b/README.md
@@ -659,7 +659,6 @@ Tree-sitter is a new system introduced in Neovim 0.5 that incrementally parses y
 - [uhs-robert/oasis.nvim](https://github.com/uhs-robert/oasis.nvim) - Desert theme from Vim ported to Neovim and made modern with 12 variants, a collection of dark themes for every color of the rainbow.
 - [sainnhe/sonokai](https://github.com/sainnhe/sonokai) - High Contrast & Vivid Color Scheme based on Monokai Pro.
 - [nyoom-engineering/oxocarbon.nvim](https://github.com/nyoom-engineering/oxocarbon.nvim) - A dark and light Neovim theme written in fennel, inspired by IBM Carbon.
-- [kyazdani42/blue-moon](https://github.com/kyazdani42/blue-moon) - A dark color scheme derived from palenight and carbonight.
 - [mhartington/oceanic-next](https://github.com/mhartington/oceanic-next) - Oceanic Next theme.
 - [nvimdev/zephyr-nvim](https://github.com/nvimdev/zephyr-nvim) - A dark colorscheme with Tree-sitter support.
 - [rockerBOO/boo-colorscheme-nvim](https://github.com/rockerBOO/boo-colorscheme-nvim) - A colorscheme with handcrafted support for LSP, Tree-sitter.


### PR DESCRIPTION
### Repo URL:

https://github.com/kyazdani42/blue-moon

### Reasoning:

The repository lacks a `LICENSE` file.

---

@kyazdani42 If you want this plugin to be re-added please license your plugin.

Sorry for the inconvenience!
