### PR TITLE
Remove `PHSix/nvim-hybrid`

### DIFF
--- a/README.md
+++ b/README.md
@@ -669,7 +669,6 @@ Tree-sitter is a new system introduced in Neovim 0.5 that incrementally parses y
 - [theniceboy/nvim-deus](https://github.com/theniceboy/nvim-deus) - Vim-deus with Tree-sitter support.
 - [bkegley/gloombuddy](https://github.com/bkegley/gloombuddy) - Gloom inspired theme.
 - [Th3Whit3Wolf/one-nvim](https://github.com/Th3Whit3Wolf/one-nvim) - An Atom One inspired dark and light colorscheme.
-- [PHSix/nvim-hybrid](https://github.com/PHSix/nvim-hybrid) - A Neovim colorscheme write in Lua.
 - [Th3Whit3Wolf/space-nvim](https://github.com/Th3Whit3Wolf/space-nvim) - A spacemacs inspired dark and light colorscheme.
 - [yonlu/omni.vim](https://github.com/yonlu/omni.vim) - Omni color scheme for Vim.
 - [ray-x/aurora](https://github.com/ray-x/aurora) - A 24-bit dark theme with Tree-sitter and LSP support.


### PR DESCRIPTION
### Repo URL:

https://github.com/PHSix/nvim-hybrid

### Reasoning:

The repository lacks a `LICENSE` file.

---

@PHSix If you want this plugin to be re-added please license your plugin.

Sorry for the inconvenience!
