### PR TITLE
Remove `yonlu/omni.vim`

### DIFF
--- a/README.md
+++ b/README.md
@@ -670,7 +670,6 @@ Tree-sitter is a new system introduced in Neovim 0.5 that incrementally parses y
 - [bkegley/gloombuddy](https://github.com/bkegley/gloombuddy) - Gloom inspired theme.
 - [Th3Whit3Wolf/one-nvim](https://github.com/Th3Whit3Wolf/one-nvim) - An Atom One inspired dark and light colorscheme.
 - [Th3Whit3Wolf/space-nvim](https://github.com/Th3Whit3Wolf/space-nvim) - A spacemacs inspired dark and light colorscheme.
-- [yonlu/omni.vim](https://github.com/yonlu/omni.vim) - Omni color scheme for Vim.
 - [ray-x/aurora](https://github.com/ray-x/aurora) - A 24-bit dark theme with Tree-sitter and LSP support.
 - [ray-x/starry.nvim](https://github.com/ray-x/starry.nvim) - A collection of modern Neovim colorschemes: material, moonlight, dracula (blood), monokai, mariana, emerald, earlysummer, middlenight_blue, darksolar.
 - [tanvirtin/monokai.nvim](https://github.com/tanvirtin/monokai.nvim) - Monokai theme written in Lua.


### PR DESCRIPTION
### Repo URL:

https://github.com/yonlu/omni.vim

### Reasoning:

The repository lacks a `LICENSE` file.

---

@yonlu If you want this plugin to be re-added please license your plugin.

Sorry for the inconvenience!
