### PR TITLE
Remove `tiagovla/tokyodark.nvim`

### DIFF
--- a/README.md
+++ b/README.md
@@ -712,7 +712,6 @@ Tree-sitter is a new system introduced in Neovim 0.5 that incrementally parses y
 - [rebelot/kanagawa.nvim](https://github.com/rebelot/kanagawa.nvim) - Neovim dark colorscheme inspired by the colors of the famous painting by Katsushika Hokusai.
 - [thesimonho/kanagawa-paper.nvim](https://github.com/thesimonho/kanagawa-paper.nvim) - Remixed light and dark Kanagawa colourschemes with muted colors.
 - [kevinm6/kurayami.nvim](https://github.com/kevinm6/kurayami.nvim) - Dark (only) theme.
-- [tiagovla/tokyodark.nvim](https://github.com/tiagovla/tokyodark.nvim) - A clean dark theme written in Lua (Neovim >= 0.5) and above.
 - [cpea2506/one_monokai.nvim](https://github.com/cpea2506/one_monokai.nvim) - One Monokai theme written in Lua.
 - [phha/zenburn.nvim](https://github.com/phha/zenburn.nvim) - A low-contrast dark colorscheme with support for various plugins.
 - [kvrohit/rasmus.nvim](https://github.com/kvrohit/rasmus.nvim) - A dark color scheme written in Lua ported from [rsms/sublime-theme](https://github.com/rsms/sublime-theme) theme.


### PR DESCRIPTION
### Repo URL:

https://github.com/tiagovla/tokyodark.nvim

### Reasoning:

The repository lacks a `LICENSE` file.

---

@tiagovla If you want this plugin to be re-added please license your plugin.

Sorry for the inconvenience!
