### PR TITLE
Remove `yazeed1s/oh-lucy.nvim`

### DIFF
--- a/README.md
+++ b/README.md
@@ -722,7 +722,6 @@ Tree-sitter is a new system introduced in Neovim 0.5 that incrementally parses y
 - [Mofiqul/adwaita.nvim](https://github.com/Mofiqul/adwaita.nvim) - Colorscheme based on GNOME Adwaita syntax with support for popular plugins.
 - [mellow-theme/mellow.nvim](https://github.com/mellow-theme/mellow.nvim) - A soothing dark color scheme with Tree-sitter support.
 - [gbprod/nord.nvim](https://github.com/gbprod/nord.nvim) - An arctic, north-bluish clean and elegant Neovim theme, based on Nord Palette.
-- [Yazeed1s/oh-lucy.nvim](https://github.com/Yazeed1s/oh-lucy.nvim) - Two Tree-sitter supported colorschemes, inspired by oh-lucy in vscode.
 - [embark-theme/vim](https://github.com/embark-theme/vim) - A deep inky purple theme leveraging bright colors.
 - [nyngwang/nvimgelion](https://github.com/nyngwang/nvimgelion) - Neon Genesis Evangelion but for Vimmers.
 - [maxmx03/fluoromachine.nvim](https://github.com/maxmx03/fluoromachine.nvim) - Synthwave x Fluoromachine port.


### PR DESCRIPTION
### Repo URL:

https://github.com/yazeed1s/oh-lucy.nvim

### Reasoning:

The repository lacks a `LICENSE` file.

---

@yazeed1s If you want this plugin to be re-added please license your plugin.

Sorry for the inconvenience!
