### PR TITLE
Remove `flashcodes-themayankjha/fkthemes.nvim`

### DIFF
--- a/README.md
+++ b/README.md
@@ -788,7 +788,6 @@ These colorschemes may not specialize in Tree-sitter directly but are written in
 
 ### Colorscheme Switchers
 
-- [flashcodes-themayankjha/fkthemes.nvim](https://github.com/flashcodes-themayankjha/fkthemes.nvim) - A fast,lightweight and powerful theme switcher written in Lua. Easily switch between your favorite colorschemes, add transparency, preview them live, and persist your choice across sessions.
 - [4e554c4c/darkman.nvim](https://github.com/4e554c4c/darkman.nvim) - Follow the system dark-mode setting on Linux.
 - [f-person/auto-dark-mode.nvim](https://github.com/f-person/auto-dark-mode.nvim) - Follow the system appearance on macOS.
 - [zaldih/themery.nvim](https://github.com/zaldih/themery.nvim) - A new way to change the colorscheme on the fly like in vscode.


### PR DESCRIPTION
### Repo URL:

https://github.com/flashcodes-themayankjha/fkthemes.nvim

### Reasoning:

The repository lacks a `LICENSE` file.

---

@flashcodes-themayankjha If you want this plugin to be re-added please license your plugin.

Sorry for the inconvenience!
