### PR TITLE
Remove `Kurama622/profile.nvim`

### DIFF
--- a/README.md
+++ b/README.md
@@ -875,7 +875,6 @@ These colorschemes may not specialize in Tree-sitter directly but are written in
 - [TobinPalmer/Tip.nvim](https://github.com/TobinPalmer/Tip.nvim) - Get a simple tip when you launch Neovim.
 - [CWood-sdf/spaceport.nvim](https://github.com/CWood-sdf/spaceport.nvim) - The start screen that gets you to your projects blazingly fast.
 - [mong8se/actually.nvim](https://github.com/mong8se/actually.nvim) - Load the file you actually meant to load.
-- [Kurama622/profile.nvim](https://github.com/Kurama622/profile.nvim) - Your personal homepage.
 
 <!--lint disable double-link -->
 


### PR DESCRIPTION
### Repo URL:

https://github.com/Kurama622/profile.nvim

### Reasoning:

The repository lacks a `LICENSE` file.

---

@Kurama622 If you want this plugin to be re-added please license your plugin.

Sorry for the inconvenience!
