### PR TITLE
Remove `ThePrimeagen/vim-be-good`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1670,7 +1670,6 @@ These colorschemes may not specialize in Tree-sitter directly but are written in
 
 ## Game
 
-- [ThePrimeagen/vim-be-good](https://github.com/ThePrimeagen/vim-be-good) - Vim-be-good is a Neovim plugin designed to make you better at Vim Movements.
 - [alec-gibson/nvim-tetris](https://github.com/alec-gibson/nvim-tetris) - Bringing emacs' greatest feature to Neovim - Tetris!.
 - [seandewar/nvimesweeper](https://github.com/seandewar/nvimesweeper) - Play Minesweeper in your favourite text editor.
 - [seandewar/killersheep.nvim](https://github.com/seandewar/killersheep.nvim) - Neovim port of killersheep.


### PR DESCRIPTION
### Repo URL:

https://github.com/ThePrimeagen/vim-be-good

### Reasoning:

The repository lacks a `LICENSE` file.

---

@ThePrimeagen If you want this plugin to be re-added please license your plugin.

Sorry for the inconvenience!
