### PR TITLE
Remove `antonk52/bad-practices.nvim`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1696,7 +1696,6 @@ These colorschemes may not specialize in Tree-sitter directly but are written in
 ## Workflow
 
 - [m4xshen/hardtime.nvim](https://github.com/m4xshen/hardtime.nvim) - Helping you establish good command workflow and habit.
-- [antonk52/bad-practices.nvim](https://github.com/antonk52/bad-practices.nvim) - Helping you give up bad practices in Vim.
 - [saxon1964/neovim-tips](https://github.com/saxon1964/neovim-tips) - Provides hundreds of built-in Neovim tips, tricks, and shortcuts, with a custom picker interface and the ability to add your own tips.
 
 <!--lint disable double-link -->


### PR DESCRIPTION
### Repo URL:

https://github.com/antonk52/bad-practices.nvim

### Reasoning:

The repository lacks a `LICENSE` file.

---

@antonk52 If you want this plugin to be re-added please license your plugin.

Sorry for the inconvenience!
