### PR TITLE
Remove `Cris-lml007/NeoPlus`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1718,7 +1718,6 @@ These colorschemes may not specialize in Tree-sitter directly but are written in
 
 ## Preconfigured Configuration
 
-- [Cris-lml007/NeoPlus](https://github.com/Cris-lml007/NeoPlus) - NeoPlus is a free, open source IDE with tools that works on Neovim.
 - [pgosar/CyberNvim](https://github.com/pgosar/CyberNvim) - The world's simplest and most extensible Neovim distribution.
 - [sontungexpt/stinvim](https://github.com/sontungexpt/stinvim) - Ready Neovim's configuration for fullstack developers.
 - [Abstract-IDE/Abstract](https://github.com/Abstract-IDE/Abstract) - Abstract, The Neovim configuration to achieve the power of Modern IDE.


### PR DESCRIPTION
### Repo URL:

https://github.com/Cris-lml007/NeoPlus

### Reasoning:

The repository lacks a `LICENSE` file.

---

@Cris-lml007 If you want this plugin to be re-added please license your plugin.

Sorry for the inconvenience!
