### PR TITLE
Remove `jonathandion/web-dev.nvim`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1742,7 +1742,6 @@ These colorschemes may not specialize in Tree-sitter directly but are written in
 - [cunderw/nvim](https://github.com/cunderw/nvim) - Neovim custom configuration, focused on JS/TS, Go, and Java development. Very IDE like.
 - [otavioschwanck/mood-nvim](https://github.com/otavioschwanck/mood-nvim) - Ready to use configuration for Ruby on Rails, JavaScript and Typescript.
 - [ldelossa/nvim-ide](https://github.com/ldelossa/nvim-ide) - A full featured IDE layer heavily inspired by VSCode.
-- [jonathandion/web-dev.nvim](https://github.com/jonathandion/web-dev.nvim) - Small, simple and flexible configuration for web development.
 - [linrongbin16/lin.nvim](https://github.com/linrongbin16/lin.nvim) - A highly configured Neovim distribution integrated with tons of utilities for development, inspired by spf13-vim.
 - [doctorfree/nvim-lazyman](https://github.com/doctorfree/nvim-lazyman) - Neovim configuration manager and modular configuration, supports over 40 preconfigured configurations.
 - [NormalNvim/NormalNvim](https://github.com/NormalNvim/NormalNvim) - Focused on stability for your daily work. From the creator of Compiler.nvim.


### PR DESCRIPTION
### Repo URL:

https://github.com/jonathandion/web-dev.nvim

### Reasoning:

The repository lacks a `LICENSE` file.

---

@jonathandion If you want this plugin to be re-added please license your plugin.

Sorry for the inconvenience!
