### PR TITLE
Add `esmuellert/vscode-diff.nvim`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1330,6 +1330,7 @@ These colorschemes may not specialize in Tree-sitter directly but are written in
 - [404pilo/aicommits.nvim](https://github.com/404pilo/aicommits.nvim) - Generate conventional commit messages using AI.
 - [wsdjeg/git.nvim](https://github.com/wsdjeg/git.nvim) - An asynchronous git command wrapper plugin, using `:Git` command instead of `:!git`.
 - [Mauritz8/gitstatus.nvim](https://github.com/Mauritz8/gitstatus.nvim) - Interactive Git status window with support for staging, unstaging, and committing files.
+- [esmuellert/vscode-diff.nvim](https://github.com/esmuellert/vscode-diff.nvim) - VSCode-style side-by-side diff with two-tier highlighting (line + character level) using VSCode's algorithm implemented in C.
 
 ### GitHub
 


### PR DESCRIPTION
VSCode-style side-by-side diff with two-tier highlighting (line + character level) using VSCode's algorithm implemented in C.

**Plugin details:**
- Repository: https://github.com/esmuellert/vscode-diff.nvim
- License: MIT
- Version: 1.0.0 (just released)
- Features: VSCode-identical diff algorithm, two-tier highlighting, Git integration, async operations

**Checklist:**
- [x] Plugin is Neovim-specific
- [x] Plugin is functional and usable (v1.0.0 released)
- [x] Open-source license (MIT)
- [x] Quality README with installation and usage instructions
- [x] Active maintenance (just released)
- [x] Entry added at end of Git section
- [x] Description follows format (no word 'plugin', ends with period)
- [x] PR title follows format: `Add \`username/repo\``