### PR TITLE
Add `letieu/jira.nvim`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1729,6 +1729,7 @@ then it is not supported:
 
 ## Workflow
 
+- [letieu/jira.nvim](https://github.com/letieu/jira.nvim) - Manage Jira tasks with a beautiful UI.
 - [m4xshen/hardtime.nvim](https://github.com/m4xshen/hardtime.nvim) - Helping you establish good command workflow and habit.
 - [saxon1964/neovim-tips](https://github.com/saxon1964/neovim-tips) - Provides hundreds of built-in Neovim tips, tricks, and shortcuts, with a custom picker interface and the ability to add your own tips.
 


### PR DESCRIPTION
**NOTE**: I wasn't sure whether put it in the "Note Taking" section or in the current one.

"_Why not the Utility section?_" - Refer to my arguments in #2046.

---

~@letieu Please add a license to your plugin if you intend to have it listed here!
We suggest MIT/Apache-2.0, but it is your choice.~

~Thanks for reading!~

---

### Repo URL:

https://github.com/letieu/jira.nvim

### Checklist:

- [X] The plugin is specifically built for Neovim.
- [x] The plugin is licensed.
- [X] The lines end with a `.`. This is to conform to `awesome-list` linting and requirements.
- [X] The title of the pull request is ```Add/Update/Remove `username/repo` ``` (notice the backticks around ``` `username/repo` ```) when adding a new plugin.
- [X] The description doesn't mention that it's a Neovim plugin, it's obvious from the rest of the document. No mentions of the word `plugin` unless it's related to something else. No `.. for Neovim`.
- [X] The description doesn't contain emojis.
- [X] Neovim is spelled as `Neovim` (not `nvim`, `NeoVim` or `neovim`), Vim is spelled as `Vim` (capitalized), Lua is spelled as `Lua` (capitalized), Tree-sitter is spelled as `Tree-sitter`.
- [X] Acronyms (`LSP`, `TS`, `YAML`, etc.) are fully capitalized.
