### PR TITLE
Add `kuri-sun/comment-graph.nvim`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1731,8 +1731,7 @@ then it is not supported:
 ## Workflow
 
 <!-- lint disable double-link -->
-
-- [kuri-sun/comment-graph.nvim](https://github.com/kuri-sun/comment-graph.nvim) - Neovim plugin for [comment-graph](https://github.com/kuri-sun/comment-graph) that makes your codebase traceable at a glance.
+- [kuri-sun/comment-graph.nvim](https://github.com/kuri-sun/comment-graph.nvim) - Integration with [comment-graph](https://github.com/kuri-sun/comment-graph) that makes your codebase traceable at a glance.
 <!-- lint enable double-link -->
 - [letieu/jira.nvim](https://github.com/letieu/jira.nvim) - Manage Jira tasks with a beautiful UI.
 - [m4xshen/hardtime.nvim](https://github.com/m4xshen/hardtime.nvim) - Helping you establish good command workflow and habit.


### PR DESCRIPTION
### Repo URL:

https://github.com/kuri-sun/comment-graph.nvim

### Checklist:

- [x] The plugin is specifically built for Neovim.
- [x] The plugin is licensed.
- [x] The lines end with a `.`. This is to conform to `awesome-list` linting and requirements.
- [x] The title of the pull request is ```Add/Update/Remove `username/repo` ``` (notice the backticks around ``` `username/repo` ```) when adding a new plugin.
- [ ] The description doesn't mention that it's a Neovim plugin, it's obvious from the rest of the document. No mentions of the word `plugin` unless it's related to something else. No `.. for Neovim`.
- [x] The description doesn't contain emojis.
- [ ] Neovim is spelled as `Neovim` (not `nvim`, `NeoVim` or `neovim`), Vim is spelled as `Vim` (capitalized), Lua is spelled as `Lua` (capitalized), Tree-sitter is spelled as `Tree-sitter`.
- [x] Acronyms (`LSP`, `TS`, `YAML`, etc.) are fully capitalized.
