### PR TITLE
Update `williamboman/mason.nvim`

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@
 
 ### LSP Installer
 
-- [williamboman/mason.nvim](https://github.com/williamboman/mason.nvim) - Portable package manager that runs everywhere Neovim runs. Easily install and manage LSP servers, DAP servers, linters, and formatters.
+- [mason-org/mason.nvim](https://github.com/mason-org/mason.nvim) - Portable package manager that runs everywhere Neovim runs. Easily install and manage LSP servers, DAP servers, linters, and formatters.
 
 ### Diagnostics
 


### PR DESCRIPTION
### Repo URL:

https://github.com/mason-org/mason.nvim

The owner changed to the org.

### Checklist:

- [-] The plugin is specifically built for Neovim.
- [-] The plugin is licensed.
- [-] The lines end with a `.`. This is to conform to `awesome-list` linting and requirements.
- [x] The title of the pull request is ```Add/Update/Remove `username/repo` ``` (notice the backticks around ``` `username/repo` ```) when adding a new plugin.
- [-] The description doesn't mention that it's a Neovim plugin, it's obvious from the rest of the document. No mentions of the word `plugin` unless it's related to something else. No `.. for Neovim`.
- [-] The description doesn't contain emojis.
- [-] Neovim is spelled as `Neovim` (not `nvim`, `NeoVim` or `neovim`), Vim is spelled as `Vim` (capitalized), Lua is spelled as `Lua` (capitalized), Tree-sitter is spelled as `Tree-sitter`.
- [-] Acronyms (`LSP`, `TS`, `YAML`, etc.) are fully capitalized.
