### PR TITLE
Remove `someone-stole-my-name/yaml-companion.nvim`

### DIFF
--- a/README.md
+++ b/README.md
@@ -316,7 +316,6 @@
 
 ### YAML
 
-- [someone-stole-my-name/yaml-companion.nvim](https://github.com/someone-stole-my-name/yaml-companion.nvim) - Get, set and autodetect YAML schemas in your buffers.
 - [cuducos/yaml.nvim](https://github.com/cuducos/yaml.nvim) - Utils to work with YAML files.
 
 ### Web Development


### PR DESCRIPTION
### Repo URL:

https://github.com/someone-stole-my-name/yaml-companion.nvim

### Reasoning:

The repository has been archived and [no longer works, seemingly](https://github.com/someone-stole-my-name/yaml-companion.nvim/issues).
