### PR TITLE
Remove `altermo/vim-plugin-list`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1742,7 +1742,6 @@ Have a problem a plugin can solve? Add it to the [nvim-lua wishlist](https://git
 
 - [Vimawesome](https://vimawesome.com/) - Showcases various plugins for Vim and has a [Neovim tag](https://vimawesome.com/?q=tag:neovim) for other Neovim-related plugins.
 - [akrawchyk/awesome-vim#tools](https://github.com/akrawchyk/awesome-vim#tools) - A short list of Vim plugins and helpful guides.
-- [altermo/vim-plugin-list](https://github.com/altermo/vim-plugin-list) - List of Vim and Neovim plugins.
 <!--lint disable double-link -->
 [**⬆ back to top**](#contents)
 <!--lint enable double-link -->


### PR DESCRIPTION
### Reasoning:

The plugin's been archived and has been explicitly unmaintained by the author.

Also, quoting the repo's `README.md`:

> _NOTE: this list may contain: mirrors, extensions to plugins, links that are not working and other things that are not related to vim plugins._
>
> _NOTE: this list was documented over a span of multiple months and has some weirdness (in othe words, it would not be weird to presume that I was high when writing this (I was not))._
>
> _Other BETER vim plugin lists: [awesome-vim](https://github.com/akrawchyk/awesome-vim), [awesome-nvim](https://github.com/rockerBOO/awesome-neovim), [neovim-official-list](https://github.com/neovim/neovim/wiki/Related-projects#plugins), [vim-galore](https://github.com/mhinz/vim-galore/blob/master/PLUGINS.md), [](https://github.com/astier/vlugins)_

@altermo

### Repo URL:

https://github.com/altermo/vim-plugin-list

