### PR TITLE
Add rails_nvim and recent_rails.nvim to Web Development

### DIFF
--- a/README.md
+++ b/README.md
@@ -338,6 +338,8 @@ It has some [builtin plugins](https://neovim.io/doc/user/plugins.html#plugins) a
 - [abidibo/nvim-httpyac](https://github.com/abidibo/nvim-httpyac) - Provides integration with `httpYac`.
 - [rodrigoscc/nurl.nvim](https://github.com/rodrigoscc/nurl.nvim) - HTTP client with requests defined in pure Lua.
 - [cjodo/convert.nvim](https://github.com/cjodo/convert.nvim) - Helps with CSS unit conversions.
+- [tednguyendev/rails_nvim](https://github.com/tednguyendev/rails_nvim) - Rails navigation and smart go-to-definition.
+- [tednguyendev/recent_rails.nvim](https://github.com/tednguyendev/recent_rails.nvim) - Telescope picker for recent Rails actions, views, and errors.
 
 ### Markdown and LaTeX
 


### PR DESCRIPTION
## Description

Adding two Neovim plugins for Rails development:

- **rails_nvim** - Rails navigation and smart go-to-definition
- **recent_rails.nvim** - Telescope picker for recent Rails actions, views, and errors

## Checklist

- [x] Plugin is Neovim-specific (not just Vim)
- [x] Plugin has a README with installation instructions
- [x] Plugin is actively maintained
- [x] Entry follows the format: `- [author/repo](url) - Short description.`