### PR TITLE
Update `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,11 @@ CLAUDE.md
 
 # Session reviews
 sessions/
+
+# Python
+Pipfile
+Pipfile.lock
+venv
+.venv
+requirements.txt
+uv.lock


### PR DESCRIPTION
### Description:

I'm formatting some files with a custom Python script[^1][^2] on our `scripts/` folder, but since my OS (Arch btw) is prohibiting me from using `pip` in a global context I have to use virtual environments to install it (I use `Pipenv`, specifically).

This doesn't really affect anything, mind you. Just a good way to prevent accidentally commited files from being merged.

[^1]: https://pypi.org/project/vim-eof-comment/
[^2]: https://github.com/DrKJeff16/vim-eof-comment