### PR TITLE
Add `kiyoon/repeatable-move.nvim`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1294,7 +1294,7 @@ then it is not supported:
 - [Aaronik/Treewalker.nvim](https://github.com/aaronik/Treewalker.nvim) - Move seamlessly around the abstract syntax tree.
 - [timseriakov/spamguard.nvim](https://github.com/timseriakov/spamguard.nvim) - Detects excessive key spamming (jjjj/kkkk) and suggests more efficient alternatives.
 - [millerjason/neovimacs.nvim](https://github.com/millerjason/neovimacs.nvim) - Provides Emacs movement and buffer keybindings while in insert mode.
-- [kiyoon/repeatable-move.nvim](https://github.com/kiyoon/repeatable-move.nvim) - Make any motion repeatable with `;` and `,` keys. Works with gitsigns, LSP diagnostics, todo comments, and more.
+- [kiyoon/repeatable-move.nvim](https://github.com/kiyoon/repeatable-move.nvim) - Make any motion repeatable with `;` and `,` keys.
 
 ### Tree-sitter Based
 


### PR DESCRIPTION
<!--
PLEASE make sure to read the CONTRIBUTING.md file!
https://github.com/rockerBOO/awesome-neovim/blob/main/CONTRIBUTING.md
-->

### Repo URL:

https://github.com/kiyoon/repeatable-move.nvim

### Checklist:

<!-- Is your plugin a colorscheme? Then uncomment this section (and remove this line).
- [ ] The plugin is a colorscheme and has been properly tagged.
-->
- [x] The plugin is specifically built for Neovim.
- [x] The plugin is licensed.
- [x] The lines end with a `.`. This is to conform to `awesome-list` linting and requirements.
- [x] The title of the pull request is ```Add/Update/Remove `username/repo` ``` (notice the backticks around ``` `username/repo` ```) when adding a new plugin.
- [x] The description doesn't mention that it's a Neovim plugin, it's obvious from the rest of the document. No mentions of the word `plugin` unless it's related to something else. No `.. for Neovim`.
- [x] The description doesn't contain emojis.
- [x] Neovim is spelled as `Neovim` (not `nvim`, `NeoVim` or `neovim`), Vim is spelled as `Vim` (capitalized), Lua is spelled as `Lua` (capitalized), Tree-sitter is spelled as `Tree-sitter`.
- [x] Acronyms (`LSP`, `TS`, `YAML`, etc.) are fully capitalized.
