### PR TITLE
Update `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,12 @@ venv
 .venv
 requirements.txt
 uv.lock
+
+# Useless Files
+*.bak
+*.dll
+*.in
+*.lock
+*.log
+*.new
+*.out


### PR DESCRIPTION
### Description:

I noticed that when attempting to run `scripts/fix-yamllint.sh` manually a bunch of `.bak` files are created, which are currently not ignored by Git:

```bash
./scripts/fix-yamllint.sh # This will create backup files for all YAML files in the repo
```

I've fixed this by adding the aforementioned file extension, aswell as other potentially intrusive ones, to `.gitignore`.
