### PR TITLE
Add `iwe-org/iwe.nvim`

### DIFF
--- a/README.md
+++ b/README.md
@@ -986,7 +986,7 @@ then it is not supported:
 - [nbeversl/urtext_neovim](https://github.com/nbeversl/urtext_neovim) - An implementation of Urtext.
 - [losch/ztl](https://codeberg.org/losch/ztl) - A fast static note generator in a single binary with everything built-in.
 - [indium114/studytools.nvim](https://github.com/indium114/studytools.nvim) - Various utilities to enhance the studying and note-taking experience.
-- [iwe-org/iwe.nvim](https://github.com/iwe-org/iwe.nvim) - Integration with `IWE`, an LSP designed for Markdown-based knowledge management and note-taking workflows.
+- [iwe-org/iwe.nvim](https://github.com/iwe-org/iwe.nvim) - LSP-powered markdown knowledge management with go-to-definition, backlinks, link completion, and code actions.
 - [carloscalla/notepad.nvim](https://github.com/carloscalla/notepad.nvim) - Quick note-taking in Markdown with both repo-specific and global notepad support.
 <!--lint disable double-link -->
 [**⬆ back to top**](#contents)


### PR DESCRIPTION
IWE is an LSP-powered markdown knowledge management plugin. It provides go-to-definition for links, find references (backlinks), link autocompletion, code actions (extract/inline), hover preview, and inlay hints.

Powered by a Rust LSP server. Works with markdown knowledge bases of any size.

GitHub: https://github.com/iwe-org/iwe.nvim