### PR TITLE
Update `readme-check.sh`

### DIFF
--- a/README.md
+++ b/README.md
@@ -510,7 +510,7 @@ It has some [builtin plugins](https://neovim.io/doc/user/plugins.html#plugins) a
 - [wurli/visimatch.nvim](https://github.com/wurli/visimatch.nvim) - Adds highlights to any text matching the current selection in visual mode.
 - [kevinhwang91/nvim-hlslens](https://github.com/kevinhwang91/nvim-hlslens) - Helps you better glance searched information, seamlessly jump matched instances.
 - [rktjmp/highlight-current-n.nvim](https://github.com/rktjmp/highlight-current-n.nvim) - Highlights the current /, ? or \* match under your cursor when pressing n or N and gets out of the way afterwards.
-- [ray-x/sad.nvim](https://github.com/ray-x/sad.nvim) - Space Age seD integration. Batch file edit tool, a wrapper for [sad](https://github.com/ms-jpq/sad)
+- [ray-x/sad.nvim](https://github.com/ray-x/sad.nvim) - Space Age seD integration. Batch file edit tool, a wrapper for [sad](https://github.com/ms-jpq/sad).
 - [s1n7ax/nvim-search-and-replace](https://github.com/s1n7ax/nvim-search-and-replace) - Search and replace in multiple files at the same time from the current working directory.
 - [AckslD/muren.nvim](https://github.com/AckslD/muren.nvim/) - Multiple replacements through interactive UI.
 - [nvim-pack/nvim-spectre](https://github.com/nvim-pack/nvim-spectre) - Search and replace panel.
@@ -520,7 +520,7 @@ It has some [builtin plugins](https://neovim.io/doc/user/plugins.html#plugins) a
 - [FabianWirth/search.nvim](https://github.com/FabianWirth/search.nvim) - Tabs for different Telescope pickers.
 - [backdround/improved-search.nvim](https://github.com/backdround/improved-search.nvim) - Add search abilities.
 - [polirritmico/telescope-lazy-plugins.nvim](https://github.com/polirritmico/telescope-lazy-plugins.nvim) - A Telescope picker to quickly access plugins configurations from the lazy.nvim spec.
-- [MagicDuck/grug-far.nvim](https://github.com/MagicDuck/grug-far.nvim) - Buffer-based live search and replace with full power of `rg` flags. Grug like!
+- [MagicDuck/grug-far.nvim](https://github.com/MagicDuck/grug-far.nvim) - Buffer-based live search and replace with full power of `rg` flags. Grug like.
 - [chrisgrieser/nvim-rip-substitute](https://github.com/chrisgrieser/nvim-rip-substitute) - Search and replace in the current buffer or workspace with incremental preview, a convenient UI, and modern regex syntax.
 - [wsdjeg/flygrep.nvim](https://github.com/wsdjeg/flygrep.nvim) - Search text in a floating window asynchronously.
 - [prochri/telescope-all-recent.nvim](https://github.com/prochri/telescope-all-recent.nvim) - Frequency and recency sorter for any Telescope picker.
@@ -873,7 +873,7 @@ then it is not supported:
 - [nvim-lualine/lualine.nvim](https://github.com/nvim-lualine/lualine.nvim) - Easily configurable, blazingly fast statusline.
 - [adelarsq/neoline.vim](https://github.com/adelarsq/neoline.vim) - A light statusline/tabline plugin using Lua.
 - [ojroques/nvim-hardline](https://github.com/ojroques/nvim-hardline) - A statusline / bufferline inspired by [vim-airline](https://github.com/vim-airline/vim-airline) that aims to be as light and simple as possible.
-- [beauwilliams/statusline.lua](https://github.com/beauwilliams/statusline.lua) - A zero-config minimal statusline written in Lua featuring awesome integrations and blazing speed!
+- [beauwilliams/statusline.lua](https://github.com/beauwilliams/statusline.lua) - A zero-config minimal statusline written in Lua featuring awesome integrations and blazing speed.
 - [tamton-aquib/staline.nvim](https://github.com/tamton-aquib/staline.nvim) - A modern lightweight statusline in Lua. Mainly uses unicode symbols for showing info.
 - [windwp/windline.nvim](https://github.com/windwp/windline.nvim) - The next generation statusline. Animation statusline.
 - [konapun/vacuumline.nvim](https://github.com/konapun/vacuumline.nvim) - A galaxyline configuration inspired by airline.
@@ -1645,7 +1645,7 @@ then it is not supported:
 - [yorickpeterse/nvim-window](https://github.com/yorickpeterse/nvim-window) - Easily jump between windows.
 - [sindrets/winshift.nvim](https://github.com/sindrets/winshift.nvim) - Rearrange your windows with ease.
 - [nvim-focus/focus.nvim](https://github.com/nvim-focus/focus.nvim) - Auto-Focusing and Auto-Resizing Splits/Windows written in Lua! Vim splits on steroids.
-- [anuvyklack/windows.nvim](https://github.com/anuvyklack/windows.nvim) - Automatically expand width of the current window. Maximizes and restore it. And all this with nice animations!
+- [anuvyklack/windows.nvim](https://github.com/anuvyklack/windows.nvim) - Automatically expand width of the current window. Maximizes and restore it. And all this with nice animations.
 - [nvim-zh/colorful-winsep.nvim](https://github.com/nvim-zh/colorful-winsep.nvim) - A configurable color split line.
 - [nyngwang/NeoNoName.lua](https://github.com/nyngwang/NeoNoName.lua) - Layout preserving buffer deletion.
 - [nvim-mini/mini.nvim#mini.bufremove](https://github.com/nvim-mini/mini.nvim/blob/main/readmes/mini-bufremove.md) - Module of `mini.nvim` for buffer removing (unshow, delete, wipeout) while saving window layout.
@@ -1747,7 +1747,7 @@ then it is not supported:
 - [sontungexpt/stinvim](https://github.com/sontungexpt/stinvim) - Configuration for Full-Stack developers.
 - [Abstract-IDE/Abstract](https://github.com/Abstract-IDE/Abstract) - Configuration to achieve the power of Modern IDE.
 - [SpaceVim/SpaceVim](https://spacevim.org) - A community-driven modular Vim/Neovim distribution, inspired by `spacemacs`.
-- [CosmicNvim/CosmicNvim](https://github.com/CosmicNvim/CosmicNvim) - CosmicNvim is a lightweight and opinionated config for web development, specifically designed to provide a COSMIC programming experience!
+- [CosmicNvim/CosmicNvim](https://github.com/CosmicNvim/CosmicNvim) - CosmicNvim is a lightweight and opinionated config for web development, specifically designed to provide a COSMIC programming experience.
 - [artart222/CodeArt](https://github.com/artart222/CodeArt) - A fast general-purpose IDE written entirely in Lua with an installer for Linux/Windows/macOS and built-in `:CodeArtUpdate` command for updating it.
 - [LazyVim/LazyVim](https://github.com/LazyVim/LazyVim) - Full-fledged IDE powered by **lazy.nvim** to make it easy to customize and extend your config.
 - [legobeat/l7-devenv](https://github.com/legobeat/l7-devenv) - Security-focused IDE with a hackable (in the right way) framework based on Neovim and shell.

--- a/scripts/readme-check.sh
+++ b/scripts/readme-check.sh
@@ -13,6 +13,7 @@ PUNCTUATION=0
 SUPPORTED=()
 BACKUPS=()
 BACKUP=""
+MISSING_LOG="./scripts/missing.log"
 
 # Output colors
 MAGENTA=""
@@ -20,7 +21,6 @@ RED=""
 GREEN=""
 BOLD=""
 RESET=""
-
 
 # Print each argument as a line to stderr
 error() {
@@ -66,8 +66,6 @@ verbose_print() {
 #
 # Usage: die [[<EXIT_CODE>] <MESSAGE> [<MESSAGE> [...]]]
 die() {
-    rm -f "${BACKUPS[@]}"
-
     local EC=0
     if [[ $# -ge 1 ]] && [[ $1 =~ ^(0|-?[1-9][0-9]*)$ ]]; then
         EC="$1"
@@ -81,6 +79,8 @@ die() {
             error "${TXT[@]}"
         fi
     fi
+
+    rm -f "${BACKUPS[@]}" "${MISSING_LOG}"
     exit "$EC"
 }
 
@@ -273,6 +273,58 @@ check_api() {
     return 0
 }
 
+# Check that every list element has a dot `.` at the end
+check_list_punctuation() {
+    trap 'die_sigint' SIGINT # Will result in pressing Ctrl-C aborting safely
+
+    local MSG="Fixing punctuation at the end of list items  ==>  "
+    local EC=0
+    local FOUND=0
+    if ! grep -nE '^-\s\[.*\]\(.*\)\s-\s.*[^\.]$' ./README.md 2> /dev/null | tee "${MISSING_LOG}" > /dev/null; then
+        MSG+="UNCHANGED"
+    else
+        FOUND=1
+        BACKUP="$(mktemp -p .)"
+        BACKUPS+=("${BACKUP}")
+        cp ./README.md "${BACKUP}"
+
+        local IFS
+        local LNUMS=()
+        IFS=$'\n' LNUMS=($(cat "${MISSING_LOG}"))
+
+        for I in $(seq 1 ${#LNUMS[@]}); do
+            I=$((I - 1))
+            local END=""
+            END="$(echo "${LNUMS[I]}" | rev)"
+            local LEN=${#END[@]}
+            ((LEN++))
+
+            END="${END:${LEN}:1}"
+
+            if [[ "${END}" =~ ^[a-zA-Z0-9\)].*$ ]]; then
+                sed -E -i "$(echo "${LNUMS[I]}" | cut -d ':' -f1)s/[^\.]$/${END}./g" ./README.md || EC=1
+            else
+                sed -E -i "$(echo "${LNUMS[I]}" | cut -d ':' -f1)s/[^\.]$/./g" ./README.md || EC=1
+            fi
+            if [[ $EC -eq 1 ]]; then
+                FOUND=0
+                MSG+="${RED}ERROR"
+                break
+            fi
+        done
+
+        if [[ $FOUND -eq 1 ]] && has_diff "${BACKUP}"; then
+            MSG+="${GREEN}CHANGED"
+        else
+            MSG+="UNCHANGED"
+        fi
+    fi
+
+    sleep .5s
+    verbose_print "" "${RESET}${BOLD}${MSG}${RESET}"
+    return $EC
+}
+
 # Check for bad & punctuation
 check_punctuation() {
     trap 'die_sigint' SIGINT # Will result in pressing Ctrl-C aborting safely
@@ -281,6 +333,7 @@ check_punctuation() {
     fi
 
     fix_suspected_lines '\&' 'and' || die 1 "Error while analyzing punctuations"
+    check_list_punctuation || die 1 "Error while analyzing punctuations"
     return 0
 }
 
@@ -641,8 +694,9 @@ check_trail_spaces() {
         return 0
     fi
 
-    local MSG="Fixing ${MAGENTA}Trailing Spaces${RESET}${BOLD}  ==>  "
+    local MSG="Fixing Trailing Spaces  ==>  "
     local FOUND=0
+    local EC=0
     BACKUP=""
     if search_regex '\s+$'; then
         # If regex is found then backup README to temporary file and indicate that
@@ -670,7 +724,8 @@ check_trail_spaces() {
             MSG+="UNCHANGED"
         fi
 
-        verbose_print "${BOLD}${MSG}${RESET}"
+        sleep .5s
+        verbose_print "" "${BOLD}${MSG}${RESET}"
     fi
 
     return $EC
@@ -759,7 +814,6 @@ if [[ $# -gt 0 ]]; then
     done
 fi
 
-
 if [[ $USE_COLORS -eq 1 ]] && _cmd_exists 'tput'; then
     MAGENTA="$(tput setaf 5)"
     RED="$(tput setaf 1)"
@@ -775,9 +829,9 @@ if [[ "${PUNCTUATION}${CAPITALIZATION}${TRAIL_SPACES}" == "000" ]]; then
     CAPITALIZATION=1
 fi
 
-check_capitalizations || die 1
-check_punctuation     || die 1
-check_trail_spaces    || die 1
+check_capitalizations  || die 1
+check_trail_spaces     || die 1
+check_punctuation      || die 1
 
 # Will run if `-L` is passed
 [[ $LIST_SUPPORTED -eq 1 ]] && print_sort "${SUPPORTED[@]}"


### PR DESCRIPTION
### Description:

I've added a new component to the script that auto-corrects for any missing dot (`.`) on a list entry.

The new component will replace any non "dot" character at the end of a plugin line with an actual dot.

> [!IMPORTANT]
> **_There is a special case for closing brackets!_**

This took a while to get working consistently, so that only plugin lines get affected, but I've got it!

Please let me know if you have any feedback.