### PR TITLE
Add `zaakiy/line-justice.nvim`

### DIFF
--- a/README.md
+++ b/README.md
@@ -862,6 +862,7 @@ then it is not supported:
 - [mawkler/hml.nvim](https://github.com/mawkler/hml.nvim) - Adds `H`/`M`/`L` indicators to your line numbers.
 - [neur1n/noline.nvim](https://github.com/neur1n/noline.nvim) - Fully customizable bars and lines components with no presets nor constraints.
 - [OXY2DEV/bars.nvim](https://github.com/OXY2DEV/bars.nvim) - A starting point/guide for creating custom statusline, statuscolumn, tabline and winbar.
+- [zaakiy/line-justice.nvim](https://github.com/zaakiy/line-justice.nvim) - Shows both absolute and relative line numbers simultaneously.
 
 ### Statusline
 


### PR DESCRIPTION
Add `zaakiy/line-justice.nvim`

Shows both absolute and relative line numbers simultaneously

<!--
If this is a PR for a new plugin,
DO NOT OVERWRITE THIS PR TEMPLATE! Use this format only.

PLEASE make sure to read the CONTRIBUTING.md file!
https://github.com/rockerBOO/awesome-neovim/blob/main/CONTRIBUTING.md
-->

### Repo URL:

https://github.com/zaakiy/line-justice.nvim/

### Checklist:

<!-- Is your plugin a colorscheme? Then uncomment this section (and remove this line).
- [ ] The plugin is a colorscheme and has been properly tagged.
-->
- [x] The plugin is specifically built for Neovim.
- [x] The plugin is licensed.
- [x] The lines end with a `.`. This is to conform to `awesome-list` linting and requirements.
- [x] The title of the pull request is ```Add/Update/Remove `username/repo` ``` (notice the backticks around ``` `username/repo` ```) when adding a new plugin.
- [x] The description doesn't mention that it's a Neovim plugin, it's obvious from the rest of the document. No mentions of the word `plugin` unless it's related to something else. No `.. for Neovim`.
- [x] The description doesn't contain emojis.
- [x] Neovim is spelled as `Neovim` (not `nvim`, `NeoVim` or `neovim`), Vim is spelled as `Vim` (capitalized), Lua is spelled as `Lua` (capitalized), Tree-sitter is spelled as `Tree-sitter`.
- [x] Acronyms (`LSP`, `TS`, `YAML`, etc.) are fully capitalized.
