### PR TITLE
Add graphite.nvim — Neovim plugin for Graphite CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1333,6 +1333,7 @@ then it is not supported:
 - [spacedentist/resolve.nvim](https://github.com/spacedentist/resolve.nvim) - Resolve merge conflicts with ease.
 - [jceb/jiejie.nvim](https://github.com/jceb/jiejie.nvim) - Frontend for Jujutsu in the style of `fugitive`.
 - [chojs23/ec](https://github.com/chojs23/ec) - A TUI native Git mergetool with 3 panes.
+- [dshan12/graphite.nvim](https://github.com/dshan12/graphite.nvim) - A Neovim plugin for the Graphite CLI with an interactive 4-pane dashboard and 40+ user commands for managing stacked Git workflows.
 
 ### GitHub
 


### PR DESCRIPTION
## Summary

Adds [graphite.nvim](https://github.com/dshan12/graphite.nvim) to the Git section.

graphite.nvim is a Neovim plugin for the [Graphite CLI](https://graphite.dev) (`gt`) that provides an interactive 4-pane TUI dashboard (Branches, Commits, Status, Diff) and 40+ user commands for managing stacked Git workflows.

- 4-pane lazygit-style dashboard in a floating window
- 40+ `:Graphite*` commands covering auth, branch, commit, stack, downstack, upstack, repo, log, and user config
- Pure Lua, zero external dependencies beyond the `gt` binary
- MIT licensed

## Checklist

- [x] The repo is MIT licensed
- [x] The plugin is Neovim-focused (requires Neovim 0.7+)
- [x] The description is accurate and concise