### PR TITLE
Add `kkew3/jieba.vim`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1390,6 +1390,7 @@ then it is not supported:
 - [timseriakov/spamguard.nvim](https://github.com/timseriakov/spamguard.nvim) - Detects excessive key spamming (jjjj/kkkk) and suggests more efficient alternatives.
 - [millerjason/neovimacs.nvim](https://github.com/millerjason/neovimacs.nvim) - Provides Emacs movement and buffer keybindings while in insert mode.
 - [kiyoon/repeatable-move.nvim](https://github.com/kiyoon/repeatable-move.nvim) - Make any motion repeatable with `;` and `,` keys.
+- [kkew3/jieba.vim](https://github.com/kkew3/jieba.vim) - Word motions and word text objects for Chinese.
 
 ### Tree-sitter Based
 


### PR DESCRIPTION
<!--
If this is a PR for a new plugin,
DO NOT OVERWRITE THIS PR TEMPLATE! Use this format only.

PLEASE make sure to read the CONTRIBUTING.md file!
https://github.com/rockerBOO/awesome-neovim/blob/main/CONTRIBUTING.md
-->

### Repo URL:

https://github.com/kkew3/jieba.vim

### Checklist:

<!-- Is your plugin a colorscheme? Then uncomment this section (and remove this line).
- [ ] The plugin is a colorscheme and has been properly tagged.
-->
- [x] The plugin is specifically built for Neovim.
- [x] The plugin is licensed.
- [x] The lines end with a `.`. This is to conform to `awesome-list` linting and requirements.
- [x] The title of the pull request is ```Add/Update/Remove `username/repo` ``` (notice the backticks around ``` `username/repo` ```) when adding a new plugin.
- [x] The description doesn't mention that it's a Neovim plugin, it's obvious from the rest of the document. No mentions of the word `plugin` unless it's related to something else. No `.. for Neovim`.
- [x] The description doesn't contain emojis.
- [x] Neovim is spelled as `Neovim` (not `nvim`, `NeoVim` or `neovim`), Vim is spelled as `Vim` (capitalized), Lua is spelled as `Lua` (capitalized), Tree-sitter is spelled as `Tree-sitter`.
- [x] Acronyms (`LSP`, `TS`, `YAML`, etc.) are fully capitalized.

---

**Quick note**:

I ticked `The plugin is specifically built for Neovim.` because `jieba.vim` satisfies the condition:

> The plugin must be both compatible and usable in Neovim.

While not built only for Neovim, `jieba.vim` is designed to be *dual-compatible* with Vim and Neovim. It achieved this by having Lua bridge `lua/jieba_vim/init.lua` when run in Neovim and Python3 bridge under `pythonx/` when in Vim. Please refer to the README ([en](https://github.com/kkew3/jieba.vim#en), [zh-cn](https://github.com/kkew3/jieba.vim#jiebavim-vimnvim-的中文按词跳转插件)) of jieba.vim for details.