### PR TITLE
Add `Rimkomatic/vimtagger.nvim`

### DIFF
--- a/README.md
+++ b/README.md
@@ -603,6 +603,7 @@ It has some [builtin plugins](https://neovim.io/doc/user/plugins.html#plugins) a
 - [martuscellifaria/ahoicpp.nvim](https://github.com/martuscellifaria/ahoicpp.nvim) - Sets up C++ projects on a modular fashion and helps newcomers with the language heavy lifting.
 - [OscarCreator/rsync.nvim](https://github.com/OscarCreator/rsync.nvim) - Automatically sync up/down project to a remote with rsync.
 - [zachyarbrough/anchor.nvim](https://github.com/zachyarbrough/anchor.nvim) - Pin project-specific directories for instant fuzzy searching. Inspired by Harpoon.
+- [Rimkomatic/vimtagger.nvim](https://github.com/Rimkomatic/vimtagger.nvim) - Semantic file tagging for projects with Telescope integration. Organize files using custom tags, search them quickly, and manage tags through an interactive UI.
 <!--lint disable double-link -->
 [**⬆ back to top**](#contents)
 <!--lint enable double-link -->


### PR DESCRIPTION
`vimtagger.nvim` is a Neovim plugin for navigating large codebases using semantic file tags. It stores tags per project, integrates with Telescope for searching, and provides an interface for managing tags and tagged files.

### Repo URL:

https://github.com/Rimkomatic/vimtagger.nvim


### Checklist:

* [x] The plugin is specifically built for Neovim.
* [x] The plugin is licensed.
* [x] The lines end with a `.`. This is to conform to `awesome-list` linting and requirements.
* [x] The title of the pull request is `Add \`username/repo`` when adding a new plugin.
* [x] The description doesn't mention that it's a Neovim plugin, it's obvious from the rest of the document. No mentions of the word `plugin` unless it's related to something else. No `.. for Neovim`.
* [x] The description doesn't contain emojis.
* [x] Neovim is spelled as `Neovim` (not `nvim`, `NeoVim` or `neovim`), Vim is spelled as `Vim` (capitalized), Lua is spelled as `Lua` (capitalized), Tree-sitter is spelled as `Tree-sitter`.
* [x] Acronyms (`LSP`, `TS`, `YAML`, etc.) are fully capitalized.
