### PR TITLE
Add check.nvim - anti-hallucination engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,6 +242,7 @@ It has some [builtin plugins](https://neovim.io/doc/user/plugins.html#plugins) a
 - [0xble/dotagent.nvim](https://github.com/0xble/dotagent.nvim) - Command and skill completion for Claude Code and Codex-style prompt editors, configurable from local agent command and skill directories.
 - [blob42/codegpt-ng.nvim](https://github.com/blob42/codegpt-ng.nvim) - Minimalist command based AI coding with a powerful template system. Supports Ollama, OpenAI and more.
 - [ray-x/copilot-agent.nvim](https://github.com/ray-x/copilot-agent.nvim) - GitHub Copilot agent runtime with native tool execution, session persistence, and fine-grained permissions.
+- [golproductions/check.nvim](https://github.com/golproductions/check.nvim) - Anti-hallucination firewall. Validates AI-generated commands before execution against real system state.
 - [Aaronik/GPTModels.nvim](https://github.com/Aaronik/GPTModels.nvim) - GPTModels - a stable, clean, multi model, window based LLM AI tool.
 - [Robitx/gp.nvim](https://github.com/Robitx/gp.nvim) - ChatGPT like sessions and instructable text/code operations in your favorite editor.
 - [jackMort/ChatGPT.nvim](https://github.com/jackMort/ChatGPT.nvim) - Effortless Natural Language Generation with OpenAI's ChatGPT API.

--- a/README.md
+++ b/README.md
@@ -193,6 +193,7 @@ It has some [builtin plugins](https://neovim.io/doc/user/plugins.html#plugins) a
 - [chrisgrieser/nvim-rulebook](https://github.com/chrisgrieser/nvim-rulebook) - Add inline-comments to ignore rules, or lookup rule documentation online.
 - [artemave/workspace-diagnostics.nvim](https://github.com/artemave/workspace-diagnostics.nvim) - Populate diagnostics for all projects files, not just the opened ones.
 - [Kurama622/clean-diagnostic](https://github.com/Kurama622/clean-diagnostic) - Display diagnostic count using virtual text, and show diagnostic details in a floating window.
+- [golproductions/check.nvim](https://github.com/golproductions/check.nvim) - The universal anti-hallucination engine. Catches hallucinated commands, imports, and function calls before they reach your project.
 <!--lint disable double-link -->
 [**⬆ back to top**](#contents)
 <!--lint enable double-link -->


### PR DESCRIPTION
Adds [check.nvim](https://github.com/golproductions/check.nvim) to the Diagnostics section.

Check is the universal anti-hallucination engine for AI coding agents. It catches hallucinated commands, imports, and function calls before they reach your project. Deterministic, sub-100ms, no AI inside.

- [Product page](https://www.golproductions.com/check.html)
- [npm package](https://www.npmjs.com/package/@golproductions/check)