### PR TITLE
Add samuelnihoul/priotodo.nvim to Note Taking

### DIFF
--- a/README.md
+++ b/README.md
@@ -1018,6 +1018,7 @@ then it is not supported:
 - [iwe-org/iwe.nvim](https://github.com/iwe-org/iwe.nvim) - Integration with `IWE`, an LSP designed for Markdown-based knowledge management and note-taking workflows.
 - [carloscalla/notepad.nvim](https://github.com/carloscalla/notepad.nvim) - Quick note-taking in Markdown with both repo-specific and global notepad support.
 - [MattHandzel/taskwarrior.nvim](https://github.com/MattHandzel/taskwarrior.nvim) - Edit Taskwarrior tasks in a buffer, render tasks as Markdown checkboxes, bulk-edit with Vim motions, diff-and-apply on save. Inspired by oil.nvim.
+- [samuelnihoul/priotodo.nvim](https://github.com/samuelnihoul/priotodo.nvim) - Self-sorting plain-text todo lists with numeric priorities, due dates and a project-wide dashboard.
 <!--lint disable double-link -->
 [**⬆ back to top**](#contents)
 <!--lint enable double-link -->


### PR DESCRIPTION
## Description

[priotodo.nvim](https://github.com/samuelnihoul/priotodo.nvim) — self-sorting plain-text todo lists: tasks are ordinary lines like `3. [ ] water the plants due:2026-08-01` in Markdown/text files, re-sorted by priority on save (done tasks sink). Quick-add with inline priority/due, priority bumping, overdue highlighting, and a project-wide floating dashboard where tasks can be toggled directly.

MIT licensed, no dependencies, includes vimdoc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)