### PR TITLE
Add Action to auto-close disputed PRs

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Stale
         uses: actions/stale@v11
         with:
-          any-of-pr-labels: disputed
+          any-of-pr-labels: changes-required
           close-pr-label: closed
           close-pr-message: |
             This Pull Request has been closed after requesting changes 7 days ago.

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -4,7 +4,6 @@ on:
     - cron: '30 1 * * *'
 permissions:
   actions: write
-  contents: write
   pull-requests: write
 jobs:
   stale:
@@ -22,5 +21,4 @@ jobs:
           days-before-stale: -1
           exempt-draft-pr: true
           exempt-pr-labels: maintenance
-          ignore-pr-updates: true
           repo-token: ${{ github.token }}

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,26 @@
+name: Close PRs With Label
+on:
+  schedule:
+    - cron: '30 1 * * *'
+permissions:
+  actions: write
+  contents: write
+  pull-requests: write
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Stale
+        uses: actions/stale@v11
+        with:
+          any-of-pr-labels: disputed
+          close-pr-label: closed
+          close-pr-message: |
+            This Pull Request has been closed after requesting changes 7 days ago.
+            Feel free to make a new Pull Request, with all the requested changes being applied.
+          days-before-pr-close: 7
+          days-before-stale: -1
+          exempt-draft-pr: true
+          exempt-pr-labels: maintenance
+          ignore-pr-updates: true
+          repo-token: ${{ github.token }}


### PR DESCRIPTION
### Description:

Added workflow that auto-closes any PRs with the "disputed" label after 7 days.

@rockerBOO I need your input with this one, I'm not used to using this action :c