### PR TITLE
Add `art220/dancheong.nvim`

### DIFF
--- a/README.md
+++ b/README.md
@@ -828,6 +828,7 @@ then it is not supported:
 - [brargenzilian/darcula-solid.nvim](https://codeberg.org/brargenzilian/darcula-solid.nvim) - **_`[TS][Lua]`_** A color-scheme that was heavily inspired by the JetBrains IntelliJ IDEA default theme, but was carefully refined to bring a more pleasant, aesthetic, and contrasting experience.
 - [tan-wei/zimablue.nvim](https://github.com/tan-wei/zimablue.nvim) - **_`[TS][LSP][Lua]`_** A dark Neovim colorscheme inspired by the iconic color from the _Love, Death and Robots_ episode _Zima Blue_.
 - [mitander/flume.nvim](https://github.com/mitander/flume.nvim) - **_`[TS][LSP][L/D][Lua]`_** Four-palette color system with consistent semantic roles and matching generated themes for terminal and developer tools.
+- [art220/dancheong.nvim](https://github.com/art220/dancheong.nvim) - **_`[TS][LSP][L/D][Lua]`_** Four variants drawn from dancheong, the 1,500-year-old Korean temple-painting palette, with every color contrast-gated at build time and a matching lualine theme.
 <!--lint disable double-link -->
 [**⬆ back to top**](#contents)
 <!--lint enable double-link -->


### PR DESCRIPTION
### Repo URL:

https://github.com/art220/dancheong.nvim

### Checklist:

- [x] The plugin is a colorscheme and has been properly tagged.
- [x] The plugin is specifically built for Neovim.
- [x] The plugin is licensed.
- [x] The lines end with a `.`. This is to conform to `awesome-list` linting and requirements.
- [x] The title of the pull request is ```Add/Update/Remove `username/repo` ``` (notice the backticks around ``` `username/repo` ```) when adding a new plugin.
- [x] The description doesn't mention that it's a Neovim plugin, it's obvious from the rest of the document. No mentions of the word `plugin` unless it's related to something else. No `.. for Neovim`.
- [x] The description doesn't contain emojis.
- [x] Neovim is spelled as `Neovim` (not `nvim`, `NeoVim` or `neovim`), Vim is spelled as `Vim` (capitalized), Lua is spelled as `Lua` (capitalized), Tree-sitter is spelled as `Tree-sitter`.
- [x] Acronyms (`LSP`, `TS`, `YAML`, etc.) are fully capitalized.

---

Notes on the tags, since all four are claimed:

- `[TS]` — Tree-sitter captures including the granular ones (`@variable.parameter`, `@keyword.return`, `@markup.heading.*`, `@string.escape`).
- `[LSP]` — semantic tokens via `@lsp.type.*` and `@lsp.typemod.*`.
- `[L/D]` — `dancheong-dawn` sets `background = "light"`; the other three are dark.
- `[Lua]` — four files under `colors/`, 376 highlight groups each, plus a lualine theme per variant.

The repository was created today, so per the acceptance criteria it is not a week old yet.

`awesome-lint@1.2.0` passes locally on this branch (the only message is `awesome-github`, which fires because the checkout is a fork clone).