### PR TITLE
Add `DRoma82/add-subtract-ex.nvim`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1483,6 +1483,7 @@ then it is not supported:
 - [m4xshen/autoclose.nvim](https://github.com/m4xshen/autoclose.nvim) - A minimalist autoclose plugin written in Lua.
 - [altermo/ultimate-autopair.nvim](https://github.com/altermo/ultimate-autopair.nvim) - Autopair with extensions.
 - [monaqa/dial.nvim](https://github.com/monaqa/dial.nvim) - Extended increment/decrement.
+- [DRoma82/add-subtract-ex.nvim](https://github.com/DRoma82/add-subtract-ex.nvim) - Extends `<C-a>`/`<C-x>` to toggle booleans, comparison/logical operators, and shift letters, deferring to native number handling.
 - [HiPhish/rainbow-delimiters.nvim](https://github.com/HiPhish/rainbow-delimiters.nvim) - Rainbow delimiters with Tree-sitter.
 - [AckslD/nvim-trevJ.lua](https://github.com/AckslD/nvim-trevJ.lua) - Does the opposite of join-line (J) for arguments, powered by Tree-sitter.
 - [okuuva/auto-save.nvim](https://github.com/okuuva/auto-save.nvim) - Automatically saves your work as often as needed and as seldom as possible. Customizable with smart defaults. Maintained fork of Pocco81/auto-save.nvim.


### PR DESCRIPTION
### Repo URL:

https://github.com/DRoma82/add-subtract-ex.nvim

### Checklist:

- [x] The plugin is specifically built for Neovim.
- [x] The plugin is licensed.
- [x] The lines end with a `.`. This is to conform to `awesome-list` linting and requirements.
- [x] The title of the pull request is `Add/Update/Remove `username/repo`` (notice the backticks around `username/repo`) when adding a new plugin.
- [x] The description does not mention that it is a Neovim plugin; it is obvious from the rest of the document. No mentions of the word `plugin` unless related to something else. No `.. for Neovim`.
- [x] The description does not contain emojis.
- [x] Neovim is spelled as `Neovim`, Vim is spelled as `Vim`, Lua is spelled as `Lua`, Tree-sitter is spelled as `Tree-sitter`.
- [x] Acronyms (`LSP`, `TS`, `YAML`, etc.) are fully capitalized.