### PR TITLE
Add `overflow/fs-review.nvim`

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,6 +282,7 @@ It has some [builtin plugins](https://neovim.io/doc/user/plugins.html#plugins) a
 - [alsi-lawr/agent-term.nvim](https://github.com/alsi-lawr/agent-term.nvim) - Terminal-agent UI with persistent views, lightweight hook-based editor context, and extensible presets for any native AI TUI.
 - [ishiooon/codex.nvim](https://github.com/ishiooon/codex.nvim) - Codex IDE integration, no API key required.
 - [nickjvandyke/opencode.nvim](https://github.com/nickjvandyke/opencode.nvim) - OpenCode AI assistant integration.
+- [overflow/fs-review.nvim](https://github.com/overflow/fs-review.nvim) - Filesystem and OpenCode review panel with isolated diff tabs, project-scoped activity tracking, and live cross-process refresh.
 - [taigrr/neocrush.nvim](https://github.com/taigrr/neocrush.nvim) - Integration with Crush AI coding assistant, with edit highlighting, auto-focus, Telescope support, terminal and version management.
 - [zgs225/pi2.nvim](https://github.com/zgs225/pi2.nvim) - Frontend for the [pi](https://pi.dev) coding agent with in-editor chat, reviewed diffs, session-tree navigation, and extension prompts.
 <!--lint disable double-link -->


### PR DESCRIPTION
### Repo URL:

https://github.com/overflow/fs-review.nvim

### Checklist:

<!-- Is your plugin a colorscheme? Then uncomment this section (and remove this line).
- [ ] The plugin is a colorscheme and has been properly tagged.
-->
- [x] The plugin is specifically built for Neovim.
- [x] The plugin is licensed.
- [x] The lines end with a `.`. This is to conform to `awesome-list` linting and requirements.
- [x] The title of the pull request is ```Add/Update/Remove `username/repo` ``` (notice the backticks around ``` `username/repo` ```).
- [x] The description doesn't mention that it's a plugin.
- [x] The description doesn't contain emojis.
- [x] Neovim is spelled as `Neovim` (capitalized).
- [x] Acronyms (`LSP`, `TS`, `YAML`, etc.) are fully capitalized.

### Notes

The plugin is placed in the **AI** section right after `nickjvandyke/opencode.nvim`, since fs-review.nvim is the read/diff companion for the same OpenCode integration. The repo is brand new (first release tagged today, v0.1.0), so I'm aware of the 'a week old' guideline. Happy to retitle or move into any other section you prefer; if you'd like the `pending-merge` label until a week of history accumulates, please add it and I'll wait.